### PR TITLE
chore(icons): 🔧 collapse aux1-4 icon keys into single aux key

### DIFF
--- a/custom_components/neopool/icons.json
+++ b/custom_components/neopool/icons.json
@@ -1,25 +1,7 @@
 {
   "entity": {
     "binary_sensor": {
-      "aux1": {
-        "default": "mdi:electric-switch",
-        "state": {
-          "on": "mdi:electric-switch-closed"
-        }
-      },
-      "aux2": {
-        "default": "mdi:electric-switch",
-        "state": {
-          "on": "mdi:electric-switch-closed"
-        }
-      },
-      "aux3": {
-        "default": "mdi:electric-switch",
-        "state": {
-          "on": "mdi:electric-switch-closed"
-        }
-      },
-      "aux4": {
+      "aux": {
         "default": "mdi:electric-switch",
         "state": {
           "on": "mdi:electric-switch-closed"
@@ -169,25 +151,7 @@
       }
     },
     "switch": {
-      "aux1": {
-        "default": "mdi:electric-switch",
-        "state": {
-          "on": "mdi:electric-switch-closed"
-        }
-      },
-      "aux2": {
-        "default": "mdi:electric-switch",
-        "state": {
-          "on": "mdi:electric-switch-closed"
-        }
-      },
-      "aux3": {
-        "default": "mdi:electric-switch",
-        "state": {
-          "on": "mdi:electric-switch-closed"
-        }
-      },
-      "aux4": {
+      "aux": {
         "default": "mdi:electric-switch",
         "state": {
           "on": "mdi:electric-switch-closed"

--- a/custom_components/neopool/strings.json
+++ b/custom_components/neopool/strings.json
@@ -434,7 +434,7 @@
           "use_aux2": "[%key:component::neopool::options::step::init::data_description::use_aux1%]",
           "use_aux3": "[%key:component::neopool::options::step::init::data_description::use_aux1%]",
           "use_aux4": "[%key:component::neopool::options::step::init::data_description::use_aux1%]",
-          "use_cover_sensor": "Creates a binary sensor and enables cover-related entities (hydrolysis cover reduction, shutdown temperature).",
+          "use_cover_sensor": "Creates a binary sensor and enables the hydrolysis cover reduction switch.",
           "use_filtration1": "Creates timer entities for configuring automatic filtration schedule.",
           "use_filtration2": "[%key:component::neopool::options::step::init::data_description::use_filtration1%]",
           "use_filtration3": "[%key:component::neopool::options::step::init::data_description::use_filtration1%]",

--- a/custom_components/neopool/translations/cs.json
+++ b/custom_components/neopool/translations/cs.json
@@ -611,7 +611,7 @@
                     "use_aux2": "Vytvoří přepínač a entity časovačů pro tento pomocný reléový výstup.",
                     "use_aux3": "Vytvoří přepínač a entity časovačů pro tento pomocný reléový výstup.",
                     "use_aux4": "Vytvoří přepínač a entity časovačů pro tento pomocný reléový výstup.",
-                    "use_cover_sensor": "Vytvoří binární senzor a povolí entity související se zakrytím (redukce hydrolýzy, teplotní limit).",
+                    "use_cover_sensor": "Vytvoří binární senzor a povolí přepínač redukce hydrolýzy při zakrytí.",
                     "use_filtration1": "Vytvoří entity časovačů pro konfiguraci automatického plánu filtrace.",
                     "use_filtration2": "Vytvoří entity časovačů pro konfiguraci automatického plánu filtrace.",
                     "use_filtration3": "Vytvoří entity časovačů pro konfiguraci automatického plánu filtrace.",

--- a/custom_components/neopool/translations/de.json
+++ b/custom_components/neopool/translations/de.json
@@ -611,7 +611,7 @@
                     "use_aux2": "Erstellt Schalter- und Timer-Entitäten für diesen Hilfsrelais-Ausgang.",
                     "use_aux3": "Erstellt Schalter- und Timer-Entitäten für diesen Hilfsrelais-Ausgang.",
                     "use_aux4": "Erstellt Schalter- und Timer-Entitäten für diesen Hilfsrelais-Ausgang.",
-                    "use_cover_sensor": "Erstellt einen Binärsensor und aktiviert abdeckungsbezogene Entitäten (Hydrolyse-Reduzierung, Abschalttemperatur).",
+                    "use_cover_sensor": "Erstellt einen Binärsensor und aktiviert den Schalter zur Hydrolyse-Reduzierung bei Abdeckung.",
                     "use_filtration1": "Erstellt Timer-Entitäten zur Konfiguration des automatischen Filterplans.",
                     "use_filtration2": "Erstellt Timer-Entitäten zur Konfiguration des automatischen Filterplans.",
                     "use_filtration3": "Erstellt Timer-Entitäten zur Konfiguration des automatischen Filterplans.",

--- a/custom_components/neopool/translations/en.json
+++ b/custom_components/neopool/translations/en.json
@@ -611,7 +611,7 @@
                     "use_aux2": "Creates switch and timer entities for this auxiliary relay output.",
                     "use_aux3": "Creates switch and timer entities for this auxiliary relay output.",
                     "use_aux4": "Creates switch and timer entities for this auxiliary relay output.",
-                    "use_cover_sensor": "Creates a binary sensor and enables cover-related entities (hydrolysis cover reduction, shutdown temperature).",
+                    "use_cover_sensor": "Creates a binary sensor and enables the hydrolysis cover reduction switch.",
                     "use_filtration1": "Creates timer entities for configuring automatic filtration schedule.",
                     "use_filtration2": "Creates timer entities for configuring automatic filtration schedule.",
                     "use_filtration3": "Creates timer entities for configuring automatic filtration schedule.",

--- a/custom_components/neopool/translations/es.json
+++ b/custom_components/neopool/translations/es.json
@@ -611,7 +611,7 @@
                     "use_aux2": "Crea entidades de interruptor y temporizador para esta salida de relé auxiliar.",
                     "use_aux3": "Crea entidades de interruptor y temporizador para esta salida de relé auxiliar.",
                     "use_aux4": "Crea entidades de interruptor y temporizador para esta salida de relé auxiliar.",
-                    "use_cover_sensor": "Crea un sensor binario y habilita entidades relacionadas con la cubierta (reducción de hidrólisis, temperatura de apagado).",
+                    "use_cover_sensor": "Crea un sensor binario y habilita el interruptor de reducción de hidrólisis con cubierta.",
                     "use_filtration1": "Crea entidades de temporizador para configurar el horario automático de filtración.",
                     "use_filtration2": "Crea entidades de temporizador para configurar el horario automático de filtración.",
                     "use_filtration3": "Crea entidades de temporizador para configurar el horario automático de filtración.",

--- a/custom_components/neopool/translations/fr.json
+++ b/custom_components/neopool/translations/fr.json
@@ -611,7 +611,7 @@
                     "use_aux2": "Crée des entités d'interrupteur et de minuterie pour cette sortie relais auxiliaire.",
                     "use_aux3": "Crée des entités d'interrupteur et de minuterie pour cette sortie relais auxiliaire.",
                     "use_aux4": "Crée des entités d'interrupteur et de minuterie pour cette sortie relais auxiliaire.",
-                    "use_cover_sensor": "Crée un capteur binaire et active les entités liées à la couverture (réduction d'hydrolyse, température d'arrêt).",
+                    "use_cover_sensor": "Crée un capteur binaire et active l'interrupteur de réduction d'hydrolyse lorsque la piscine est couverte.",
                     "use_filtration1": "Crée des entités de minuterie pour configurer le programme automatique de filtration.",
                     "use_filtration2": "Crée des entités de minuterie pour configurer le programme automatique de filtration.",
                     "use_filtration3": "Crée des entités de minuterie pour configurer le programme automatique de filtration.",

--- a/custom_components/neopool/translations/it.json
+++ b/custom_components/neopool/translations/it.json
@@ -611,7 +611,7 @@
                     "use_aux2": "Crea entità interruttore e timer per questa uscita relè ausiliaria.",
                     "use_aux3": "Crea entità interruttore e timer per questa uscita relè ausiliaria.",
                     "use_aux4": "Crea entità interruttore e timer per questa uscita relè ausiliaria.",
-                    "use_cover_sensor": "Crea un sensore binario e abilita le entità relative alla copertura (riduzione idrolisi, temperatura di spegnimento).",
+                    "use_cover_sensor": "Crea un sensore binario e abilita l'interruttore di riduzione idrolisi con copertura.",
                     "use_filtration1": "Crea entità timer per configurare la programmazione automatica della filtrazione.",
                     "use_filtration2": "Crea entità timer per configurare la programmazione automatica della filtrazione.",
                     "use_filtration3": "Crea entità timer per configurare la programmazione automatica della filtrazione.",

--- a/custom_components/neopool/translations/pl.json
+++ b/custom_components/neopool/translations/pl.json
@@ -611,7 +611,7 @@
                     "use_aux2": "Tworzy encje przełącznika i timera dla tego pomocniczego wyjścia przekaźnikowego.",
                     "use_aux3": "Tworzy encje przełącznika i timera dla tego pomocniczego wyjścia przekaźnikowego.",
                     "use_aux4": "Tworzy encje przełącznika i timera dla tego pomocniczego wyjścia przekaźnikowego.",
-                    "use_cover_sensor": "Tworzy czujnik binarny i umożliwia encje związane z przykryciem (redukcja hydrolizy, temperatura wyłączenia).",
+                    "use_cover_sensor": "Tworzy czujnik binarny i włącza przełącznik redukcji hydrolizy przy przykryciu.",
                     "use_filtration1": "Tworzy encje timerów do konfiguracji automatycznego harmonogramu filtracji.",
                     "use_filtration2": "Tworzy encje timerów do konfiguracji automatycznego harmonogramu filtracji.",
                     "use_filtration3": "Tworzy encje timerów do konfiguracji automatycznego harmonogramu filtracji.",


### PR DESCRIPTION
## 🐛 What

The auxiliary switch and binary_sensor entities all share `translation_key="aux"` after the earlier numbered-name merge, but `icons.json` still keyed their icons per number (`aux1`..`aux4`). Those keys never matched, so the aux entities rendered without an icon.

## 🔧 Changes

- 🎨 Collapse the `aux1`..`aux4` icon blocks into a single `aux` block in both the `switch` and `binary_sensor` platforms.
- 📝 Reword the `use_cover_sensor` option description to name only the hydrolysis cover reduction switch it actually gates. High-temperature shutdown is ungated (it depends on hydrolysis and temperature capabilities, not cover presence), so the old wording was misleading. Updated `strings.json` and all translation files.

## ✅ Verification

- `pytest` 332 passed, 100% coverage
- `ruff check` / `ruff format --check` clean
- all `translations/*.json` valid JSON, no stale cover wording remaining
