### PR TITLE
fix(button): 🐛 broaden reset counters label and gating

### DIFF
--- a/custom_components/neopool/button.py
+++ b/custom_components/neopool/button.py
@@ -18,7 +18,11 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any, override
 
-from neopool_modbus.capabilities import is_hydrolysis_present
+from neopool_modbus.capabilities import (
+    is_hydrolysis_present,
+    is_ionization_present,
+    is_uv_lamp_present,
+)
 from neopool_modbus.exceptions import NeoPoolError
 
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
@@ -63,7 +67,11 @@ BUTTON_DESCRIPTIONS: dict[str, NeoPoolButtonEntityDescription] = {
         translation_key="reset_cell_partial",
         entity_category=EntityCategory.CONFIG,
         entity_registry_enabled_default=False,
-        supported_fn=is_hydrolysis_present,
+        supported_fn=lambda data: (
+            is_hydrolysis_present(data)
+            or is_ionization_present(data)
+            or is_uv_lamp_present(data)
+        ),
         press_fn=lambda entity: entity.coordinator.client.async_reset_user_counters(),
     ),
 }

--- a/custom_components/neopool/strings.json
+++ b/custom_components/neopool/strings.json
@@ -90,7 +90,7 @@
     },
     "button": {
       "escape": { "name": "Clear error messages" },
-      "reset_cell_partial": { "name": "Reset cell runtime counter" },
+      "reset_cell_partial": { "name": "Reset partial runtime counters" },
       "sync_time": { "name": "Synchronize device time" }
     },
     "light": { "light": { "name": "Pool light" } },

--- a/custom_components/neopool/translations/cs.json
+++ b/custom_components/neopool/translations/cs.json
@@ -151,7 +151,7 @@
                 "name": "Vymazat chybová hlášení"
             },
             "reset_cell_partial": {
-                "name": "Vynulovat čítač doby běhu komory"
+                "name": "Vynulovat čítače dílčí doby běhu"
             },
             "sync_time": {
                 "name": "Synchronizovat čas zařízení"

--- a/custom_components/neopool/translations/de.json
+++ b/custom_components/neopool/translations/de.json
@@ -151,7 +151,7 @@
                 "name": "Fehlermeldungen löschen"
             },
             "reset_cell_partial": {
-                "name": "Zellenlaufzeit-Zähler zurücksetzen"
+                "name": "Teillaufzeit-Zähler zurücksetzen"
             },
             "sync_time": {
                 "name": "Gerätezeit synchronisieren"

--- a/custom_components/neopool/translations/en.json
+++ b/custom_components/neopool/translations/en.json
@@ -151,7 +151,7 @@
                 "name": "Clear error messages"
             },
             "reset_cell_partial": {
-                "name": "Reset cell runtime counter"
+                "name": "Reset partial runtime counters"
             },
             "sync_time": {
                 "name": "Synchronize device time"

--- a/custom_components/neopool/translations/es.json
+++ b/custom_components/neopool/translations/es.json
@@ -151,7 +151,7 @@
                 "name": "Borrar mensajes de error"
             },
             "reset_cell_partial": {
-                "name": "Reiniciar contador de tiempo de uso de la celda"
+                "name": "Reiniciar contadores de tiempo de uso parcial"
             },
             "sync_time": {
                 "name": "Sincronizar hora del dispositivo"

--- a/custom_components/neopool/translations/fr.json
+++ b/custom_components/neopool/translations/fr.json
@@ -151,7 +151,7 @@
                 "name": "Effacer les messages d'erreur"
             },
             "reset_cell_partial": {
-                "name": "Réinitialiser le compteur de fonctionnement de la cellule"
+                "name": "Réinitialiser les compteurs de fonctionnement partiel"
             },
             "sync_time": {
                 "name": "Synchroniser l’heure de l’appareil"

--- a/custom_components/neopool/translations/it.json
+++ b/custom_components/neopool/translations/it.json
@@ -151,7 +151,7 @@
                 "name": "Cancella messaggi di errore"
             },
             "reset_cell_partial": {
-                "name": "Azzera contatore di funzionamento cella"
+                "name": "Azzera contatori di funzionamento parziale"
             },
             "sync_time": {
                 "name": "Sincronizza orario dispositivo"

--- a/custom_components/neopool/translations/pl.json
+++ b/custom_components/neopool/translations/pl.json
@@ -151,7 +151,7 @@
                 "name": "Wyczyść komunikaty o błędach"
             },
             "reset_cell_partial": {
-                "name": "Wyzeruj licznik czasu pracy ogniwa"
+                "name": "Wyzeruj liczniki częściowego czasu pracy"
             },
             "sync_time": {
                 "name": "Synchronizuj czas urządzenia"

--- a/tests/snapshots/test_button.ambr
+++ b/tests/snapshots/test_button.ambr
@@ -49,7 +49,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_all_entities[button.neopool_reset_cell_runtime_counter-entry]
+# name: test_all_entities[button.neopool_reset_partial_runtime_counters-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -63,7 +63,7 @@
     'disabled_by': None,
     'domain': 'button',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'button.neopool_reset_cell_runtime_counter',
+    'entity_id': 'button.neopool_reset_partial_runtime_counters',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -71,12 +71,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Reset cell runtime counter',
+    'object_id_base': 'Reset partial runtime counters',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Reset cell runtime counter',
+    'original_name': 'Reset partial runtime counters',
     'platform': 'neopool',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -86,13 +86,13 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[button.neopool_reset_cell_runtime_counter-state]
+# name: test_all_entities[button.neopool_reset_partial_runtime_counters-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'NeoPool Reset cell runtime counter',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'NeoPool Reset partial runtime counters',
     }),
     'context': <ANY>,
-    'entity_id': 'button.neopool_reset_cell_runtime_counter',
+    'entity_id': 'button.neopool_reset_partial_runtime_counters',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -12,7 +12,6 @@ from pytest_homeassistant_custom_component.common import (
 )
 from syrupy.assertion import SnapshotAssertion
 
-from custom_components.neopool.helpers import prepare_device_time
 from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
@@ -52,6 +51,9 @@ async def test_sync_time_button_writes_time_and_commit(
     freezer: FrozenDateTimeFactory,
 ) -> None:
     """SYNC_TIME button writes the encoded local time and refreshes."""
+    # Non-UTC zone so a timezone or encoding regression changes the literal.
+    await hass.config.async_set_time_zone("America/New_York")
+    freezer.move_to("2024-01-02 08:04:05+00:00")
     await setup_integration(hass, mock_config_entry)
 
     entity_id = _button_entity_id(hass, mock_config_entry, "sync_time")
@@ -59,9 +61,7 @@ async def test_sync_time_button_writes_time_and_commit(
     reads_before = mock_neopool_client.async_read_all.await_count
     await _press(hass, entity_id)
 
-    mock_neopool_client.async_sync_device_time.assert_awaited_once_with(
-        prepare_device_time(hass)
-    )
+    mock_neopool_client.async_sync_device_time.assert_awaited_once_with(1704164645)
     assert mock_neopool_client.async_read_all.await_count > reads_before
 
 
@@ -114,16 +114,17 @@ async def test_reset_cell_partial_button_disabled_by_default(
     assert matches[0].disabled_by is er.RegistryEntryDisabler.INTEGRATION
 
 
-async def test_reset_cell_partial_button_skipped_without_hydrolysis(
+async def test_reset_cell_partial_button_skipped_without_wear_modules(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     mock_config_entry: MockConfigEntry,
     mock_neopool_client: MagicMock,
 ) -> None:
-    """No RESET_CELL_PARTIAL entity is registered when hydrolysis isn't detected."""
-    no_hidro_data = dict(mock_neopool_client.async_read_all.return_value)
-    no_hidro_data["Hydrolysis module detected"] = False
-    mock_neopool_client.async_read_all.return_value = no_hidro_data
+    """No RESET_CELL_PARTIAL entity when no hydrolysis/ION/UV module is present."""
+    no_wear_data = dict(mock_neopool_client.async_read_all.return_value)
+    no_wear_data["Hydrolysis module detected"] = False
+    no_wear_data["MBF_PAR_MODEL"] = 0
+    mock_neopool_client.async_read_all.return_value = no_wear_data
 
     await setup_integration(hass, mock_config_entry)
 
@@ -135,6 +136,38 @@ async def test_reset_cell_partial_button_skipped_without_hydrolysis(
         if e.domain == BUTTON_DOMAIN and e.unique_id.endswith("_reset_cell_partial")
     ]
     assert matches == []
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        pytest.param(0x0001, id="ionization-only"),
+        pytest.param(0x0004, id="uv-only"),
+    ],
+)
+async def test_reset_cell_partial_button_registers_for_wear_modules(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+    mock_neopool_client: MagicMock,
+    model: int,
+) -> None:
+    """RESET_CELL_PARTIAL registers when ION or UV wear counters are present."""
+    data = dict(mock_neopool_client.async_read_all.return_value)
+    data["Hydrolysis module detected"] = False
+    data["MBF_PAR_MODEL"] = model
+    mock_neopool_client.async_read_all.return_value = data
+
+    await setup_integration(hass, mock_config_entry)
+
+    matches = [
+        e
+        for e in er.async_entries_for_config_entry(
+            entity_registry, mock_config_entry.entry_id
+        )
+        if e.domain == BUTTON_DOMAIN and e.unique_id.endswith("_reset_cell_partial")
+    ]
+    assert len(matches) == 1
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## 🐛 What

Broaden the reset button so its label and availability match what the underlying register actually does.

## 🔍 Why

The `RESET_CELL_PARTIAL` button calls `async_reset_user_counters`, which writes `MBF_RESET_USER_COUNTERS` (register 0x02F2). That reset clears three partial work-time counters, not just the cell:

- `MBF_PAR_PARTIAL_HIDRO_WORK_TIME`
- `MBF_PAR_PARTIAL_ION_WORK_TIME`
- `MBF_PAR_PARTIAL_UV_WORK_TIME`

The hydrolysis-only label "Reset cell runtime counter" was misleading, and gating the button on hydrolysis alone hid it on ION or UV only installations that also carry those wear counters.

## 🔧 Changes

- 🏷️ Rename the label to "Reset partial runtime counters" in `strings.json` and all locale files (cs, de, en, es, fr, it, pl).
- 🎯 Gate the button on hydrolysis OR ionization OR UV lamp so it registers whenever any of those partial work-time counters are present.
- 🔒 Keep the internal `key` and `unique_id` unchanged, so existing entities keep their `entity_id`; only the friendly name updates.
- ✅ Rewrite the sync_time test to assert a literal encoded timestamp under a non-UTC zone, instead of calling `prepare_device_time` (which made the assertion a tautology against production).
- ✅ Add an ionization-only / uv-only registration test and rename the skip test to reflect the broadened gating.

## ✔️ Verification

- `pytest` all green (334 passed, 359 snapshots), coverage unchanged (100%).
- `ruff check`, `ruff format --check`, `basedpyright` clean.
