### PR TITLE
fix(switch): 🐛 gate manual filtration on a valid filtration relay GPIO

### DIFF
--- a/custom_components/neopool/switch.py
+++ b/custom_components/neopool/switch.py
@@ -211,6 +211,9 @@ SWITCH_DESCRIPTIONS: dict[str, NeoPoolSwitchEntityDescription] = {
         translation_key="filt_manual_state",
         write_fn=_write_manual_filtration,
         is_on_fn=_make_is_on_from_key("Filtration Pump"),
+        supported_fn=lambda data: is_valid_relay_gpio(
+            data.get("MBF_PAR_FILT_GPIO", 0) or 0
+        ),
     ),
     "BACKWASH": NeoPoolSwitchEntityDescription(
         key="BACKWASH",

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -575,6 +575,30 @@ async def test_backwash_absent_without_filtvalve(
     assert matches == []
 
 
+async def test_manual_filtration_absent_without_filt_gpio(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+    mock_neopool_client: MagicMock,
+) -> None:
+    """No manual filtration switch is registered when no filtration relay exists."""
+    mock_neopool_client.async_read_all.return_value = {
+        **MOCK_POOL_DATA,
+        "MBF_PAR_FILT_GPIO": 0,
+    }
+    await setup_integration(hass, mock_config_entry)
+
+    matches = [
+        e
+        for e in er.async_entries_for_config_entry(
+            entity_registry, mock_config_entry.entry_id
+        )
+        if e.domain == SWITCH_DOMAIN
+        and e.unique_id.endswith("_mbf_par_filt_manual_state")
+    ]
+    assert matches == []
+
+
 # ---------------------------------------------------------------------------
 # option gating and snapshots
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 🐛 What

Gate the manual filtration switch (`MBF_PAR_FILT_MANUAL_STATE`) on a valid filtration relay GPIO. When `MBF_PAR_FILT_GPIO` is `0`, the controller has no relay assigned to filtration and does not expose the filter option in its own menu, so the switch is now skipped instead of being created unconditionally.

## 🤔 Why

A controller with `MBF_PAR_FILT_GPIO == 0` does not control a filtration relay. The unconditional description still created an unusable switch and allowed writes to its manual-state register.

## 🔧 How

- Add a `supported_fn` to the `MBF_PAR_FILT_MANUAL_STATE` description that returns `True` only when `is_valid_relay_gpio(MBF_PAR_FILT_GPIO)` holds.
- This mirrors the existing UV and light `supported_fn` GPIO gating already used in the platform.

## ✅ Tests

- Add `test_manual_filtration_absent_without_filt_gpio`, modeled on `test_backwash_absent_without_filtvalve`: with `MBF_PAR_FILT_GPIO: 0` no switch with the `_mbf_par_filt_manual_state` suffix is registered.
- Full suite green: 333 passed, 359 snapshots.
- `ruff check`, `ruff format --check`, and `basedpyright` all clean.
