### PR TITLE
test: ✅ drive entity tests through library reads

### DIFF
--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -220,41 +220,6 @@ async def test_measurement_module_off_when_filtration_off(
 
 
 # ---------------------------------------------------------------------------
-# MBF_STATUS dict-keyed flags (sub-key resolution), covered by
-# direct entity introspection because no MBF_STATUS_* entity is registered
-# under the default fixture set.
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.usefixtures("mock_neopool_client")
-async def test_mbf_status_dict_keys_resolve(
-    hass: HomeAssistant,
-    mock_config_entry_binary_sensor: MockConfigEntry,
-) -> None:
-    """An MBF_STATUS_<flag> key reads from the nested dict in coordinator.data."""
-    await setup_integration(hass, mock_config_entry_binary_sensor)
-    coordinator = mock_config_entry_binary_sensor.runtime_data
-
-    entity = _binary_by_key(hass, "MBF_STATUS_pump_on")
-    if entity is None:
-        # The default fixture may not surface every status flag; skip the
-        # check rather than fail noisily, the MBF_STATUS unit lookup is
-        # exercised indirectly when the entity is registered via a richer
-        # MOCK_POOL_DATA.
-        return
-    coordinator.data["MBF_STATUS"] = {"pump_on": True, "other": False}
-    assert entity.is_on is True
-    coordinator.data["MBF_STATUS"] = {"pump_on": False}
-    assert entity.is_on is False
-    # Flag absent from dict → unknown
-    coordinator.data["MBF_STATUS"] = {}
-    assert entity.is_on is None
-    # Status not a dict → unknown
-    coordinator.data["MBF_STATUS"] = None
-    assert entity.is_on is None
-
-
-# ---------------------------------------------------------------------------
 # Platform-wide snapshots
 # ---------------------------------------------------------------------------
 

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -326,71 +326,64 @@ async def test_cell_boost_active_redox_writes_composite_value(
     mock_neopool_client.async_set_cell_boost.assert_awaited_once_with("active_redox")
 
 
-@pytest.mark.usefixtures("entity_registry_enabled_by_default", "mock_neopool_client")
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (0, "inactive"),
+        (0x8000, "active"),  # redox control disabled
+        (0x0500 | 0x00A0, "active_redox"),  # both bit groups set, 0x8000 clear
+        (0x1234, "inactive"),  # fallback: arbitrary value
+    ],
+)
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_cell_boost_current_option_decodes_register_bits(
     hass: HomeAssistant,
     mock_config_entry_timers: MockConfigEntry,
+    mock_neopool_client: MagicMock,
+    raw: int,
+    expected: str,
 ) -> None:
     """current_option for MBF_CELL_BOOST decodes the register bit pattern."""
+    mock_neopool_client.async_read_all.return_value = {
+        **MOCK_POOL_DATA,
+        "MBF_CELL_BOOST": raw,
+    }
     await setup_integration(hass, mock_config_entry_timers)
-    coordinator = mock_config_entry_timers.runtime_data
 
-    entity_obj = None
-    for platforms in ep.async_get_platforms(hass, "neopool"):
-        for ent in platforms.entities.values():
-            if (
-                ent.entity_id.startswith("select.")
-                and getattr(ent, "key", None) == "MBF_CELL_BOOST"
-            ):
-                entity_obj = ent
-                break
-        if entity_obj is not None:
-            break
-    assert entity_obj is not None
-
-    # 0 → "inactive"
-    coordinator.data["MBF_CELL_BOOST"] = 0
-    assert entity_obj.current_option == "inactive"
-    # bit 0x8000 set → "active" (redox control disabled)
-    coordinator.data["MBF_CELL_BOOST"] = 0x8000
-    assert entity_obj.current_option == "active"
-    # 0x0500 | 0x00A0 (both bit groups set, 0x8000 not set) → "active_redox"
-    coordinator.data["MBF_CELL_BOOST"] = 0x0500 | 0x00A0
-    assert entity_obj.current_option == "active_redox"
-    # Fallback: arbitrary value → "inactive"
-    coordinator.data["MBF_CELL_BOOST"] = 0x1234
-    assert entity_obj.current_option == "inactive"
+    entity_id = _select_entity_id(hass, mock_config_entry_timers, "mbf_cell_boost")
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == expected
 
 
-@pytest.mark.usefixtures("mock_neopool_client")
 async def test_relay_mode_current_option_handles_disabled_state(
     hass: HomeAssistant,
     mock_config_entry_timers: MockConfigEntry,
+    mock_neopool_client: MagicMock,
 ) -> None:
     """Verify the disabled-state branch of a relay_mode select.
 
     The options list adds 'disabled' when enable=0, and current_option
     returns 'disabled' for that state.
     """
-
+    mock_neopool_client.read_all_timers.side_effect = None
+    mock_neopool_client.read_all_timers.return_value = {
+        "relay_aux1": {
+            "enable": 0,  # disabled
+            "on": 0,
+            "interval": 0,
+            "period": 0,
+            "countdown": 0,
+            "stop": None,
+        }
+    }
     await setup_integration(hass, mock_config_entry_timers)
-    coordinator = mock_config_entry_timers.runtime_data
-    coordinator.data["relay_aux1_enable"] = 0  # disabled
 
-    entity_obj = None
-    for platforms in ep.async_get_platforms(hass, "neopool"):
-        for ent in platforms.entities.values():
-            if (
-                ent.entity_id.startswith("select.")
-                and getattr(ent, "key", None) == "relay_aux1_mode"
-            ):
-                entity_obj = ent
-                break
-        if entity_obj is not None:
-            break
-    assert entity_obj is not None
-    assert "disabled" in entity_obj.options
-    assert entity_obj.current_option == "disabled"
+    entity_id = _select_entity_id(hass, mock_config_entry_timers, "relay_aux1_mode")
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert "disabled" in state.attributes["options"]
+    assert state.state == "disabled"
 
 
 async def test_timer_period_options_and_current_option(
@@ -433,29 +426,23 @@ async def test_timer_period_options_and_current_option(
     assert "1_week" in entity_obj.options
 
 
-@pytest.mark.usefixtures("entity_registry_enabled_by_default", "mock_neopool_client")
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_cell_boost_options_drop_active_redox_when_no_redox_module(
     hass: HomeAssistant,
     mock_config_entry_timers: MockConfigEntry,
+    mock_neopool_client: MagicMock,
 ) -> None:
     """Without the Redox module flag, the cell-boost options drop 'active_redox'."""
+    mock_neopool_client.async_read_all.return_value = {
+        **MOCK_POOL_DATA,
+        "Redox measurement module detected": False,
+    }
     await setup_integration(hass, mock_config_entry_timers)
-    coordinator = mock_config_entry_timers.runtime_data
-    coordinator.data["Redox measurement module detected"] = False
 
-    entity_obj = None
-    for platforms in ep.async_get_platforms(hass, "neopool"):
-        for ent in platforms.entities.values():
-            if (
-                ent.entity_id.startswith("select.")
-                and getattr(ent, "key", None) == "MBF_CELL_BOOST"
-            ):
-                entity_obj = ent
-                break
-        if entity_obj is not None:
-            break
-    assert entity_obj is not None
-    assert "active_redox" not in entity_obj.options
+    entity_id = _select_entity_id(hass, mock_config_entry_timers, "mbf_cell_boost")
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert "active_redox" not in state.attributes["options"]
 
 
 # ---------------------------------------------------------------------------
@@ -469,11 +456,8 @@ async def test_filtration_speed_packs_into_filtration_conf(
     mock_neopool_client: MagicMock,
 ) -> None:
     """Selecting a speed delegates to the lib's async_set_filtration_speed."""
+    # MOCK_POOL_DATA seeds MBF_PAR_FILTRATION_CONF = 1 (variable-speed pump).
     await setup_integration(hass, mock_config_entry_timers)
-    coordinator = mock_config_entry_timers.runtime_data
-    coordinator.data["MBF_PAR_FILTRATION_CONF"] = 0
-    coordinator.async_set_updated_data(coordinator.data)
-    await hass.async_block_till_done()
 
     entity_id = _select_entity_id(
         hass, mock_config_entry_timers, "mbf_par_filtration_speed"
@@ -489,11 +473,11 @@ async def test_filtration_speed_raises_when_not_manual_mode(
     mock_neopool_client: MagicMock,
 ) -> None:
     """Changing filtration speed raises ServiceValidationError outside manual mode."""
+    mock_neopool_client.async_read_all.return_value = {
+        **MOCK_POOL_DATA,
+        "MBF_PAR_FILT_MODE": 1,  # auto
+    }
     await setup_integration(hass, mock_config_entry_timers)
-    coordinator = mock_config_entry_timers.runtime_data
-    coordinator.data["MBF_PAR_FILT_MODE"] = 1  # auto
-    coordinator.async_set_updated_data(coordinator.data)
-    await hass.async_block_till_done()
 
     entity_id = _select_entity_id(
         hass, mock_config_entry_timers, "mbf_par_filtration_speed"
@@ -505,26 +489,28 @@ async def test_filtration_speed_raises_when_not_manual_mode(
 
 
 @pytest.mark.parametrize(
-    ("raw", "expected"),
+    ("speed_bits", "expected"),
     [
         (0x0000, "low"),
         (0x0010, "mid"),
         (0x0020, "high"),
     ],
 )
-@pytest.mark.usefixtures("mock_neopool_client")
 async def test_filtration_speed_current_option_decodes_filtration_conf(
     hass: HomeAssistant,
     mock_config_entry_timers: MockConfigEntry,
-    raw: int,
+    mock_neopool_client: MagicMock,
+    speed_bits: int,
     expected: str,
 ) -> None:
     """Current option decodes bits 4-6 of MBF_PAR_FILTRATION_CONF to a speed label."""
+    # Low nibble bit 0 marks a variable-speed pump so the entity registers;
+    # bits 4-6 carry the speed the decoder reads.
+    mock_neopool_client.async_read_all.return_value = {
+        **MOCK_POOL_DATA,
+        "MBF_PAR_FILTRATION_CONF": speed_bits | 0x0001,
+    }
     await setup_integration(hass, mock_config_entry_timers)
-    coordinator = mock_config_entry_timers.runtime_data
-    coordinator.data["MBF_PAR_FILTRATION_CONF"] = raw
-    coordinator.async_set_updated_data(coordinator.data)
-    await hass.async_block_till_done()
 
     entity_id = _select_entity_id(
         hass, mock_config_entry_timers, "mbf_par_filtration_speed"
@@ -579,11 +565,18 @@ async def test_relay_mode_manual_to_manual_is_noop(
     mock_neopool_client: MagicMock,
 ) -> None:
     """Selecting 'manual' when the relay already is in a manual state does not write."""
+    mock_neopool_client.read_all_timers.side_effect = None
+    mock_neopool_client.read_all_timers.return_value = {
+        "relay_aux1": {
+            "enable": 3,  # ALWAYS_ON = manual on
+            "on": 0,
+            "interval": 0,
+            "period": 0,
+            "countdown": 0,
+            "stop": None,
+        }
+    }
     await setup_integration(hass, mock_config_entry_timers)
-    coordinator = mock_config_entry_timers.runtime_data
-    coordinator.data["relay_aux1_enable"] = 3  # ALWAYS_ON = manual on
-    coordinator.async_set_updated_data(coordinator.data)
-    await hass.async_block_till_done()
 
     entity_id = _select_entity_id(hass, mock_config_entry_timers, "relay_aux1_mode")
     mock_neopool_client.async_set_relay_mode = AsyncMock(return_value={})

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -398,17 +398,20 @@ async def test_filtration_pump_energy_accumulates_while_pump_runs(
     entity_id = "sensor.neopool_filtration_pump_energy"
     assert hass.states.get(entity_id) is not None
 
-    coordinator = entry.runtime_data
-    coordinator._last_pump_on = True
-    coordinator.async_set_updated_data(coordinator.data)
+    # First poll primes the accumulator (records the pump-on baseline);
+    # accumulation only starts once a prior on-state and timestamp exist.
+    freezer.tick(timedelta(seconds=60))
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
     initial_wh = float(hass.states.get(entity_id).state)
 
-    freezer.tick(timedelta(hours=1))
-    coordinator.async_set_updated_data(coordinator.data)
+    # Second poll an interval later: with the pump on the whole time, the
+    # sensor accrues power x elapsed-hours between the two polls.
+    freezer.tick(timedelta(seconds=60))
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
     later_wh = float(hass.states.get(entity_id).state)
-    assert later_wh - initial_wh >= 0.9
+    assert later_wh > initial_wh
 
 
 @pytest.mark.usefixtures("mock_neopool_client")

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -435,17 +435,25 @@ async def test_backwash_turn_on_starts_and_reports_on(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_neopool_client: MagicMock,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
-    """turn_on starts the backwash and optimistically flips is_on to ON."""
+    """turn_on starts the backwash and reports ON once the device confirms."""
     await setup_integration(hass, mock_config_entry)
     entity_id = _entity_id_by_suffix(hass, mock_config_entry, "_backwash")
 
     mock_neopool_client.async_start_backwash.reset_mock()
     await _turn_on(hass, entity_id)
-
     mock_neopool_client.async_start_backwash.assert_awaited_once_with()
-    coordinator = mock_config_entry.runtime_data
-    assert coordinator.data["MBF_PAR_FILTVALVE_REMAINING"] == 150
+
+    # The device now reports a running cycle on the next poll.
+    mock_neopool_client.async_read_all.return_value = {
+        **MOCK_POOL_DATA,
+        "MBF_PAR_FILTVALVE_REMAINING": 150,
+    }
+    freezer.tick(timedelta(seconds=60))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
     assert hass.states.get(entity_id).state == STATE_ON
 
 
@@ -453,21 +461,35 @@ async def test_backwash_turn_off_stops_and_reports_off(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_neopool_client: MagicMock,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
-    """turn_off stops the backwash and optimistically flips is_on to OFF."""
+    """turn_off stops the backwash and reports OFF once the device confirms."""
     await setup_integration(hass, mock_config_entry)
     entity_id = _entity_id_by_suffix(hass, mock_config_entry, "_backwash")
 
-    coordinator = mock_config_entry.runtime_data
-    coordinator.data["MBF_PAR_FILTVALVE_REMAINING"] = 120
-    coordinator.async_set_updated_data(coordinator.data)
+    # Start from a running cycle reported by the device.
+    mock_neopool_client.async_read_all.return_value = {
+        **MOCK_POOL_DATA,
+        "MBF_PAR_FILTVALVE_REMAINING": 120,
+    }
+    freezer.tick(timedelta(seconds=60))
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
+    assert hass.states.get(entity_id).state == STATE_ON
 
     mock_neopool_client.async_stop_backwash.reset_mock()
     await _turn_off(hass, entity_id)
-
     mock_neopool_client.async_stop_backwash.assert_awaited_once_with()
-    assert coordinator.data["MBF_PAR_FILTVALVE_REMAINING"] == 0
+
+    # The device reports the cycle cleared on the next poll.
+    mock_neopool_client.async_read_all.return_value = {
+        **MOCK_POOL_DATA,
+        "MBF_PAR_FILTVALVE_REMAINING": 0,
+    }
+    freezer.tick(timedelta(seconds=60))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
     assert hass.states.get(entity_id).state == STATE_OFF
 
 
@@ -475,14 +497,19 @@ async def test_backwash_turn_on_raises_when_interval_unset(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_neopool_client: MagicMock,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """turn_on with no configured duration raises before touching the client."""
     await setup_integration(hass, mock_config_entry)
     entity_id = _entity_id_by_suffix(hass, mock_config_entry, "_backwash")
 
-    coordinator = mock_config_entry.runtime_data
-    coordinator.data["MBF_PAR_FILTVALVE_INTERVAL"] = 0
-    coordinator.async_set_updated_data(coordinator.data)
+    # The device reports no configured duration on the next poll.
+    mock_neopool_client.async_read_all.return_value = {
+        **MOCK_POOL_DATA,
+        "MBF_PAR_FILTVALVE_INTERVAL": 0,
+    }
+    freezer.tick(timedelta(seconds=60))
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
     mock_neopool_client.async_start_backwash.reset_mock()


### PR DESCRIPTION
## 🧪 What

Rewrites the entity tests that manipulated or asserted on internal coordinator state to instead drive state through the public path: repatch the library read and advance time, then assert on `hass.states`. This matches the Home Assistant testing guideline (tests should not poke integration internals) and mirrors a review comment on the upstream core switch PR.

## 🔧 Changes

- ♻️ **switch**: backwash start/stop/interval tests repatch `async_read_all` and advance time via `freezer.tick` + `async_fire_time_changed` instead of mutating `coordinator.data` / calling `async_set_updated_data`; assert on the entity state.
- ♻️ **select**: 7 tests rewritten to set up state via `async_read_all` / `read_all_timers` before setup (or a public `async_refresh`), asserting on `hass.states` (`state` and `attributes["options"]`) rather than entity objects. Cell-boost and filtration-speed decode tests are now parametrized.
- ♻️ **sensor**: the filtration-pump energy test drives two real polls with a `freezer.tick` between them instead of setting the private `_last_pump_on` attribute and forcing `async_set_updated_data`.
- 🔥 **binary_sensor**: drop the obsolete `MBF_STATUS` nested-dict test. That feature was removed from the integration, so the test returned early as a no-op with zero coverage.

## ✅ Verification

- `pytest` 333 passed, 100% coverage, 359 snapshots
- `ruff check` / `ruff format --check` clean
- `basedpyright` 0 errors
