### PR TITLE
fix(config): 🐛 harden reconfigure flow validation and input handling

### DIFF
--- a/custom_components/neopool/config_flow.py
+++ b/custom_components/neopool/config_flow.py
@@ -205,9 +205,9 @@ class NeoPoolConfigFlow(ConfigFlow, domain=DOMAIN):
             serial, error_key = await _async_probe(merged)
             if error_key:
                 errors[CONF_HOST] = error_key
-            elif entry.unique_id and serial != entry.unique_id:
-                errors[CONF_HOST] = "serial_mismatch"
             else:
+                await self.async_set_unique_id(serial)
+                self._abort_if_unique_id_mismatch(reason="serial_mismatch")
                 return self.async_update_reload_and_abort(entry, data=merged)
 
         return self.async_show_form(

--- a/custom_components/neopool/config_flow.py
+++ b/custom_components/neopool/config_flow.py
@@ -94,6 +94,15 @@ class NeoPoolConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = CURRENT_VERSION
 
+    @staticmethod
+    @callback
+    @override
+    def async_get_options_flow(
+        config_entry: NeoPoolConfigEntry,
+    ) -> "NeoPoolOptionsFlowHandler":
+        """Return the options flow handler."""
+        return NeoPoolOptionsFlowHandler()
+
     @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -170,18 +179,12 @@ class NeoPoolConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle reconfiguration of an existing entry."""
-        entry_id = self.context.get("entry_id")
-        if entry_id is None:
-            return self.async_abort(reason="entry_not_found")
-        entry = self.hass.config_entries.async_get_entry(entry_id)
-        if entry is None:
-            return self.async_abort(reason="entry_not_found")
-
+        entry = self._get_reconfigure_entry()
         current = entry.data
 
         data_schema = vol.Schema(
             {
-                vol.Required(CONF_HOST, default=current.get(CONF_HOST, "")): str,
+                vol.Required(CONF_HOST, default=current[CONF_HOST]): str,
                 vol.Optional(
                     CONF_PORT, default=current.get(CONF_PORT, DEFAULT_PORT)
                 ): vol.Coerce(int),
@@ -209,18 +212,11 @@ class NeoPoolConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="reconfigure",
-            data_schema=data_schema,
+            data_schema=self.add_suggested_values_to_schema(
+                data_schema, user_input or current
+            ),
             errors=errors,
         )
-
-    @staticmethod
-    @callback
-    @override
-    def async_get_options_flow(
-        config_entry: NeoPoolConfigEntry,
-    ) -> "NeoPoolOptionsFlowHandler":
-        """Return the options flow."""
-        return NeoPoolOptionsFlowHandler()
 
 
 class NeoPoolOptionsFlowHandler(OptionsFlowWithReload):

--- a/custom_components/neopool/const.py
+++ b/custom_components/neopool/const.py
@@ -37,11 +37,9 @@ FOLLOW_UP_REFRESH_DELAY = 2.0  # seconds  (delay before a 2nd refresh for IO ent
 DEFAULT_PORT = 502
 DEFAULT_UNIT_ID = 1
 
-# Config-entry data keys (connection settings).
 CONF_UNIT_ID = "unit_id"
 CONF_MODBUS_FRAMER = "modbus_framer"
 
-# Options-flow keys.
 CONF_FILTRATION_PUMP_POWER = "filtration_pump_power"
 CONF_MEASURE_WHEN_FILTRATION_OFF = "measure_when_filtration_off"
 CONF_USE_FILTRATION1 = "use_filtration1"

--- a/custom_components/neopool/strings.json
+++ b/custom_components/neopool/strings.json
@@ -2,7 +2,6 @@
   "config": {
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
-      "entry_not_found": "The integration entry could not be found.",
       "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
     },
     "error": {

--- a/custom_components/neopool/strings.json
+++ b/custom_components/neopool/strings.json
@@ -2,12 +2,12 @@
   "config": {
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
-      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
+      "serial_mismatch": "The device at this address has a different serial number than the one originally configured."
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "cannot_read_modbus": "Connected, but cannot read from the Modbus device. Check unit ID and framer settings.",
-      "serial_mismatch": "The device at this address has a different serial number than the one originally configured."
+      "cannot_read_modbus": "Connected, but cannot read from the Modbus device. Check unit ID and framer settings."
     },
     "step": {
       "reconfigure": {

--- a/custom_components/neopool/translations/cs.json
+++ b/custom_components/neopool/translations/cs.json
@@ -4,12 +4,12 @@
             "already_configured": "Zařízení je již nakonfigurováno",
             "migration_complete": "Migration completed successfully. Your VistaPool integration was moved to the new NeoPool domain. Please **restart Home Assistant** to clean up the old integration loaded in memory.",
             "migration_failed": "Migration failed: {error}\n\nCheck the Home Assistant logs and report the issue on GitHub. The legacy VistaPool integration is unaffected and continues to work.",
-            "reconfigure_successful": "Změna konfigurace byla úspěšná"
+            "reconfigure_successful": "Změna konfigurace byla úspěšná",
+            "serial_mismatch": "Zařízení na této adrese má jiné sériové číslo než původně nakonfigurované."
         },
         "error": {
             "cannot_connect": "Nepodařilo se připojit",
-            "cannot_read_modbus": "Připojeno, ale nelze číst z Modbus zařízení. Zkontrolujte unit ID a nastavení rámce.",
-            "serial_mismatch": "Zařízení na této adrese má jiné sériové číslo než původně nakonfigurované."
+            "cannot_read_modbus": "Připojeno, ale nelze číst z Modbus zařízení. Zkontrolujte unit ID a nastavení rámce."
         },
         "step": {
             "import_from_vistapool": {

--- a/custom_components/neopool/translations/cs.json
+++ b/custom_components/neopool/translations/cs.json
@@ -2,7 +2,6 @@
     "config": {
         "abort": {
             "already_configured": "Zařízení je již nakonfigurováno",
-            "entry_not_found": "Záznam integrace nebyl nalezen.",
             "migration_complete": "Migration completed successfully. Your VistaPool integration was moved to the new NeoPool domain. Please **restart Home Assistant** to clean up the old integration loaded in memory.",
             "migration_failed": "Migration failed: {error}\n\nCheck the Home Assistant logs and report the issue on GitHub. The legacy VistaPool integration is unaffected and continues to work.",
             "reconfigure_successful": "Změna konfigurace byla úspěšná"

--- a/custom_components/neopool/translations/de.json
+++ b/custom_components/neopool/translations/de.json
@@ -2,7 +2,6 @@
     "config": {
         "abort": {
             "already_configured": "Gerät ist bereits konfiguriert",
-            "entry_not_found": "Der Integrationseintrag wurde nicht gefunden.",
             "migration_complete": "Migration completed successfully. Your VistaPool integration was moved to the new NeoPool domain. Please **restart Home Assistant** to clean up the old integration loaded in memory.",
             "migration_failed": "Migration failed: {error}\n\nCheck the Home Assistant logs and report the issue on GitHub. The legacy VistaPool integration is unaffected and continues to work.",
             "reconfigure_successful": "Neukonfiguration war erfolgreich"

--- a/custom_components/neopool/translations/de.json
+++ b/custom_components/neopool/translations/de.json
@@ -4,12 +4,12 @@
             "already_configured": "Gerät ist bereits konfiguriert",
             "migration_complete": "Migration completed successfully. Your VistaPool integration was moved to the new NeoPool domain. Please **restart Home Assistant** to clean up the old integration loaded in memory.",
             "migration_failed": "Migration failed: {error}\n\nCheck the Home Assistant logs and report the issue on GitHub. The legacy VistaPool integration is unaffected and continues to work.",
-            "reconfigure_successful": "Neukonfiguration war erfolgreich"
+            "reconfigure_successful": "Neukonfiguration war erfolgreich",
+            "serial_mismatch": "Das Gerät an dieser Adresse hat eine andere Seriennummer als das ursprünglich konfigurierte."
         },
         "error": {
             "cannot_connect": "Verbindung fehlgeschlagen",
-            "cannot_read_modbus": "Verbunden, aber Modbus-Gerät kann nicht gelesen werden. Überprüfen Sie Unit-ID und Framer-Einstellungen.",
-            "serial_mismatch": "Das Gerät an dieser Adresse hat eine andere Seriennummer als das ursprünglich konfigurierte."
+            "cannot_read_modbus": "Verbunden, aber Modbus-Gerät kann nicht gelesen werden. Überprüfen Sie Unit-ID und Framer-Einstellungen."
         },
         "step": {
             "import_from_vistapool": {

--- a/custom_components/neopool/translations/en.json
+++ b/custom_components/neopool/translations/en.json
@@ -2,7 +2,6 @@
     "config": {
         "abort": {
             "already_configured": "Device is already configured",
-            "entry_not_found": "The integration entry could not be found.",
             "migration_complete": "Migration completed successfully. Your VistaPool integration was moved to the new NeoPool domain. Please **restart Home Assistant** to clean up the old integration loaded in memory.",
             "migration_failed": "Migration failed: {error}\n\nCheck the Home Assistant logs and report the issue on GitHub. The legacy VistaPool integration is unaffected and continues to work.",
             "reconfigure_successful": "Reconfiguration was successful"

--- a/custom_components/neopool/translations/en.json
+++ b/custom_components/neopool/translations/en.json
@@ -4,12 +4,12 @@
             "already_configured": "Device is already configured",
             "migration_complete": "Migration completed successfully. Your VistaPool integration was moved to the new NeoPool domain. Please **restart Home Assistant** to clean up the old integration loaded in memory.",
             "migration_failed": "Migration failed: {error}\n\nCheck the Home Assistant logs and report the issue on GitHub. The legacy VistaPool integration is unaffected and continues to work.",
-            "reconfigure_successful": "Reconfiguration was successful"
+            "reconfigure_successful": "Reconfiguration was successful",
+            "serial_mismatch": "The device at this address has a different serial number than the one originally configured."
         },
         "error": {
             "cannot_connect": "Failed to connect",
-            "cannot_read_modbus": "Connected, but cannot read from the Modbus device. Check unit ID and framer settings.",
-            "serial_mismatch": "The device at this address has a different serial number than the one originally configured."
+            "cannot_read_modbus": "Connected, but cannot read from the Modbus device. Check unit ID and framer settings."
         },
         "step": {
             "import_from_vistapool": {

--- a/custom_components/neopool/translations/es.json
+++ b/custom_components/neopool/translations/es.json
@@ -2,7 +2,6 @@
     "config": {
         "abort": {
             "already_configured": "El dispositivo ya está configurado",
-            "entry_not_found": "No se encontró la entrada de integración.",
             "migration_complete": "Migration completed successfully. Your VistaPool integration was moved to the new NeoPool domain. Please **restart Home Assistant** to clean up the old integration loaded in memory.",
             "migration_failed": "Migration failed: {error}\n\nCheck the Home Assistant logs and report the issue on GitHub. The legacy VistaPool integration is unaffected and continues to work.",
             "reconfigure_successful": "La reconfiguración se realizó correctamente"

--- a/custom_components/neopool/translations/es.json
+++ b/custom_components/neopool/translations/es.json
@@ -4,12 +4,12 @@
             "already_configured": "El dispositivo ya está configurado",
             "migration_complete": "Migration completed successfully. Your VistaPool integration was moved to the new NeoPool domain. Please **restart Home Assistant** to clean up the old integration loaded in memory.",
             "migration_failed": "Migration failed: {error}\n\nCheck the Home Assistant logs and report the issue on GitHub. The legacy VistaPool integration is unaffected and continues to work.",
-            "reconfigure_successful": "La reconfiguración se realizó correctamente"
+            "reconfigure_successful": "La reconfiguración se realizó correctamente",
+            "serial_mismatch": "El dispositivo en esta dirección tiene un número de serie diferente al configurado originalmente."
         },
         "error": {
             "cannot_connect": "Error al conectar",
-            "cannot_read_modbus": "Conectado, pero no se puede leer del dispositivo Modbus. Verifique el ID de unidad y la configuración del marco.",
-            "serial_mismatch": "El dispositivo en esta dirección tiene un número de serie diferente al configurado originalmente."
+            "cannot_read_modbus": "Conectado, pero no se puede leer del dispositivo Modbus. Verifique el ID de unidad y la configuración del marco."
         },
         "step": {
             "import_from_vistapool": {

--- a/custom_components/neopool/translations/fr.json
+++ b/custom_components/neopool/translations/fr.json
@@ -4,12 +4,12 @@
             "already_configured": "L'appareil est déjà configuré",
             "migration_complete": "Migration completed successfully. Your VistaPool integration was moved to the new NeoPool domain. Please **restart Home Assistant** to clean up the old integration loaded in memory.",
             "migration_failed": "Migration failed: {error}\n\nCheck the Home Assistant logs and report the issue on GitHub. The legacy VistaPool integration is unaffected and continues to work.",
-            "reconfigure_successful": "La reconfiguration a réussi"
+            "reconfigure_successful": "La reconfiguration a réussi",
+            "serial_mismatch": "L'appareil à cette adresse a un numéro de série différent de celui configuré à l'origine."
         },
         "error": {
             "cannot_connect": "Échec de la connexion",
-            "cannot_read_modbus": "Connecté, mais impossible de lire le périphérique Modbus. Vérifiez l'ID d'unité et les paramètres du cadre.",
-            "serial_mismatch": "L'appareil à cette adresse a un numéro de série différent de celui configuré à l'origine."
+            "cannot_read_modbus": "Connecté, mais impossible de lire le périphérique Modbus. Vérifiez l'ID d'unité et les paramètres du cadre."
         },
         "step": {
             "import_from_vistapool": {

--- a/custom_components/neopool/translations/fr.json
+++ b/custom_components/neopool/translations/fr.json
@@ -2,7 +2,6 @@
     "config": {
         "abort": {
             "already_configured": "L'appareil est déjà configuré",
-            "entry_not_found": "L'entrée d'intégration est introuvable.",
             "migration_complete": "Migration completed successfully. Your VistaPool integration was moved to the new NeoPool domain. Please **restart Home Assistant** to clean up the old integration loaded in memory.",
             "migration_failed": "Migration failed: {error}\n\nCheck the Home Assistant logs and report the issue on GitHub. The legacy VistaPool integration is unaffected and continues to work.",
             "reconfigure_successful": "La reconfiguration a réussi"

--- a/custom_components/neopool/translations/it.json
+++ b/custom_components/neopool/translations/it.json
@@ -2,7 +2,6 @@
     "config": {
         "abort": {
             "already_configured": "Il dispositivo è già configurato",
-            "entry_not_found": "Voce di integrazione non trovata.",
             "migration_complete": "Migration completed successfully. Your VistaPool integration was moved to the new NeoPool domain. Please **restart Home Assistant** to clean up the old integration loaded in memory.",
             "migration_failed": "Migration failed: {error}\n\nCheck the Home Assistant logs and report the issue on GitHub. The legacy VistaPool integration is unaffected and continues to work.",
             "reconfigure_successful": "La riconfigurazione è andata a buon fine"

--- a/custom_components/neopool/translations/it.json
+++ b/custom_components/neopool/translations/it.json
@@ -4,12 +4,12 @@
             "already_configured": "Il dispositivo è già configurato",
             "migration_complete": "Migration completed successfully. Your VistaPool integration was moved to the new NeoPool domain. Please **restart Home Assistant** to clean up the old integration loaded in memory.",
             "migration_failed": "Migration failed: {error}\n\nCheck the Home Assistant logs and report the issue on GitHub. The legacy VistaPool integration is unaffected and continues to work.",
-            "reconfigure_successful": "La riconfigurazione è andata a buon fine"
+            "reconfigure_successful": "La riconfigurazione è andata a buon fine",
+            "serial_mismatch": "Il dispositivo a questo indirizzo ha un numero di serie diverso da quello configurato in origine."
         },
         "error": {
             "cannot_connect": "Impossibile connettersi",
-            "cannot_read_modbus": "Connesso, ma impossibile leggere dal dispositivo Modbus. Verificare l'ID unità e le impostazioni del frame.",
-            "serial_mismatch": "Il dispositivo a questo indirizzo ha un numero di serie diverso da quello configurato in origine."
+            "cannot_read_modbus": "Connesso, ma impossibile leggere dal dispositivo Modbus. Verificare l'ID unità e le impostazioni del frame."
         },
         "step": {
             "import_from_vistapool": {

--- a/custom_components/neopool/translations/pl.json
+++ b/custom_components/neopool/translations/pl.json
@@ -4,12 +4,12 @@
             "already_configured": "Urządzenie jest już skonfigurowane",
             "migration_complete": "Migration completed successfully. Your VistaPool integration was moved to the new NeoPool domain. Please **restart Home Assistant** to clean up the old integration loaded in memory.",
             "migration_failed": "Migration failed: {error}\n\nCheck the Home Assistant logs and report the issue on GitHub. The legacy VistaPool integration is unaffected and continues to work.",
-            "reconfigure_successful": "Rekonfiguracja zakończona pomyślnie"
+            "reconfigure_successful": "Rekonfiguracja zakończona pomyślnie",
+            "serial_mismatch": "Urządzenie pod tym adresem ma inny numer seryjny niż pierwotnie skonfigurowane."
         },
         "error": {
             "cannot_connect": "Nie udało się połączyć",
-            "cannot_read_modbus": "Połączono, ale nie można odczytać danych z urządzenia Modbus. Sprawdź ID jednostki i ustawienia ramki.",
-            "serial_mismatch": "Urządzenie pod tym adresem ma inny numer seryjny niż pierwotnie skonfigurowane."
+            "cannot_read_modbus": "Połączono, ale nie można odczytać danych z urządzenia Modbus. Sprawdź ID jednostki i ustawienia ramki."
         },
         "step": {
             "import_from_vistapool": {

--- a/custom_components/neopool/translations/pl.json
+++ b/custom_components/neopool/translations/pl.json
@@ -2,7 +2,6 @@
     "config": {
         "abort": {
             "already_configured": "Urządzenie jest już skonfigurowane",
-            "entry_not_found": "Nie znaleziono wpisu integracji.",
             "migration_complete": "Migration completed successfully. Your VistaPool integration was moved to the new NeoPool domain. Please **restart Home Assistant** to clean up the old integration loaded in memory.",
             "migration_failed": "Migration failed: {error}\n\nCheck the Home Assistant logs and report the issue on GitHub. The legacy VistaPool integration is unaffected and continues to work.",
             "reconfigure_successful": "Rekonfiguracja zakończona pomyślnie"

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -253,42 +253,11 @@ async def test_reconfigure_flow_serial_mismatch(
     assert result["errors"] == {CONF_HOST: "serial_mismatch"}
 
 
-# ---------------------------------------------------------------------------
-# Edge cases on the reconfigure step
-# ---------------------------------------------------------------------------
-
-
 async def test_async_get_options_flow_returns_handler() -> None:
     """async_get_options_flow returns a NeoPoolOptionsFlowHandler instance."""
 
     handler = NeoPoolConfigFlow.async_get_options_flow(MagicMock())
     assert isinstance(handler, NeoPoolOptionsFlowHandler)
-
-
-async def test_reconfigure_flow_aborts_when_entry_id_missing(
-    hass: HomeAssistant,
-) -> None:
-    """async_step_reconfigure aborts when context has no entry_id."""
-
-    flow = NeoPoolConfigFlow()
-    flow.hass = hass
-    flow.context = {}  # no entry_id at all
-    result = await flow.async_step_reconfigure()
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "entry_not_found"
-
-
-async def test_reconfigure_flow_aborts_when_entry_not_found(
-    hass: HomeAssistant,
-) -> None:
-    """async_step_reconfigure aborts when the referenced entry was deleted."""
-
-    flow = NeoPoolConfigFlow()
-    flow.hass = hass
-    flow.context = {"entry_id": "nonexistent"}
-    result = await flow.async_step_reconfigure()
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "entry_not_found"
 
 
 @pytest.mark.usefixtures("mock_neopool_client")

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -249,8 +249,8 @@ async def test_reconfigure_flow_serial_mismatch(
                 CONF_MODBUS_FRAMER: "tcp",
             },
         )
-    assert result["type"] is FlowResultType.FORM
-    assert result["errors"] == {CONF_HOST: "serial_mismatch"}
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "serial_mismatch"
 
 
 async def test_async_get_options_flow_returns_handler() -> None:


### PR DESCRIPTION
## 🐛 Summary

Harden the **Reconfigure** flow: keep the values a user typed when validation fails, and reject a controller swap through the framework's unique-ID helper.

## 🔧 Changes

- ✨ Prefill the reconfigure form with the submitted values on retry via `add_suggested_values_to_schema`, so a probe error keeps the input instead of resetting to the stored settings.
- 🐛 Set the unique ID from the reconfigure probe and reject a serial mismatch through the `_abort_if_unique_id_mismatch` framework helper instead of a manual serial guard. The `serial_mismatch` string moves from `config.error` to `config.abort` in `strings.json` and all translations, since the helper aborts the flow.
- ♻️ Resolve the entry through the `_get_reconfigure_entry()` framework helper instead of a manual context entry-id lookup. The helper raises on a missing entry, so the unreachable `entry_not_found` abort branch is dropped.
- 🧹 Remove the now-unused `config.abort.entry_not_found` string and its translations. The `exceptions.entry_not_found` message used by services is kept.
- 🎨 Move `async_get_options_flow` above the step handlers and drop two redundant section comments in `const.py`.

## ✅ Verification

- `ruff check` and `ruff format --check`: clean
- `basedpyright`: 0 errors
- `pytest` with coverage: 331 passed, 100% coverage maintained
