### PR TITLE
refactor(migration): ♻️ replace deprecated device_registry lookup

### DIFF
--- a/custom_components/neopool/migration.py
+++ b/custom_components/neopool/migration.py
@@ -296,7 +296,9 @@ async def _migrate_v5_to_v6(hass: HomeAssistant, config_entry: ConfigEntry) -> N
                 )
 
         device_registry = dr.async_get(hass)
-        old_device = device_registry.async_get_device(identifiers={(DOMAIN, old_uid)})
+        old_device = device_registry.async_get_device_by_identifier(
+            (DOMAIN, old_uid), config_entry.entry_id
+        )
         if old_device:
             device_registry.async_update_device(
                 old_device.id, new_identifiers={(DOMAIN, new_uid)}
@@ -456,8 +458,8 @@ async def _migrate_v1_to_v2(
     # use (source_domain, new_unique_id), the cross-domain step (if any) flips the
     # source_domain part of the tuple separately.
     device_registry = dr.async_get(hass)
-    old_device = device_registry.async_get_device(
-        identifiers={(source_domain, old_entry_id)}
+    old_device = device_registry.async_get_device_by_identifier(
+        (source_domain, old_entry_id), config_entry.entry_id
     )
     if old_device:
         device_registry.async_update_device(
@@ -1060,9 +1062,12 @@ async def async_import_legacy_vistapool_entry(
     # identifier to (neopool, serial_key). Find each by that tuple
     # and re-apply the user-set fields.
     for serial_key, snap in snapshots.items():
-        device = device_registry.async_get_device(identifiers={(DOMAIN, serial_key)})
-        if device is None:
+        # The device was retargeted to the new neopool entry, so look it up by
+        # its serial identifier alone rather than a now-stale config entry id.
+        matches = device_registry.async_get_devices(identifiers={(DOMAIN, serial_key)})
+        if not matches:
             continue
+        device = matches[0]
         device_registry.async_update_device(
             device.id,
             area_id=snap["area_id"],

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -43,7 +43,9 @@ async def test_update_data_populates_firmware(
 ) -> None:
     """The first successful read populates firmware on the device entry."""
     await setup_integration(hass, mock_config_entry)
-    device = device_registry.async_get_device(identifiers={(DOMAIN, MOCK_SERIAL)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, MOCK_SERIAL), mock_config_entry.entry_id
+    )
     assert device is not None
     # MBF_POWER_MODULE_VERSION = 0x1234 → "18.52"
     assert "18.52" in (device.sw_version or "")

--- a/tests/test_init_custom.py
+++ b/tests/test_init_custom.py
@@ -57,7 +57,7 @@ async def test_async_migrate_entry_v1_to_v2_success() -> None:
     mock_old_device = MagicMock()
     mock_old_device.id = "old_device_id"
     mock_device_registry = MagicMock()
-    mock_device_registry.async_get_device.return_value = mock_old_device
+    mock_device_registry.async_get_device_by_identifier.return_value = mock_old_device
 
     # Simulate HA's behavior: async_update_entry mutates entry.version so the
     # subsequent v3→v4 marker bump can see the post-v2 state of the entry.
@@ -112,8 +112,8 @@ async def test_async_migrate_entry_v1_to_v2_success() -> None:
     # because async_migrate_entry uses source_domain=DOMAIN by default;
     # legacy vistapool entries reach this code path via the cross-domain
     # migration flow which passes source_domain="vistapool" explicitly.
-    mock_device_registry.async_get_device.assert_called_once_with(
-        identifiers={("neopool", "old_entry_id_123")}
+    mock_device_registry.async_get_device_by_identifier.assert_called_once_with(
+        ("neopool", "old_entry_id_123"), config_entry.entry_id
     )
     mock_device_registry.async_update_device.assert_called_once_with(
         "old_device_id",
@@ -202,7 +202,9 @@ async def test_async_migrate_entry_v3_to_v4_marker_bump() -> None:
         ),
         patch(
             "custom_components.neopool.migration.dr.async_get",
-            return_value=MagicMock(async_get_device=MagicMock(return_value=None)),
+            return_value=MagicMock(
+                async_get_device_by_identifier=MagicMock(return_value=None)
+            ),
         ),
     ):
         result = await async_migrate_entry(hass, config_entry)
@@ -253,7 +255,9 @@ async def test_async_migrate_entry_v4_to_v5_slave_id_renamed() -> None:
         ),
         patch(
             "custom_components.neopool.migration.dr.async_get",
-            return_value=MagicMock(async_get_device=MagicMock(return_value=None)),
+            return_value=MagicMock(
+                async_get_device_by_identifier=MagicMock(return_value=None)
+            ),
         ),
     ):
         result = await async_migrate_entry(hass, config_entry)
@@ -298,7 +302,7 @@ async def test_async_migrate_entry_v5_to_v6_drops_legacy_prefix() -> None:
     mock_old_device = MagicMock()
     mock_old_device.id = "old_device_id"
     mock_device_registry = MagicMock()
-    mock_device_registry.async_get_device.return_value = mock_old_device
+    mock_device_registry.async_get_device_by_identifier.return_value = mock_old_device
 
     def _update_entry(entry: MagicMock, **kwargs: Any) -> None:
         for k, v in kwargs.items():

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -983,7 +983,7 @@ async def test_import_legacy_vistapool_entry_runs_migration_and_restores_device(
     migrated_device.id = "device_1"  # same row, same id
 
     device_registry = MagicMock()
-    device_registry.async_get_device.return_value = migrated_device
+    device_registry.async_get_devices.return_value = [migrated_device]
 
     with (
         patch(
@@ -1080,7 +1080,7 @@ async def test_import_legacy_vistapool_entry_skips_restore_when_migrated_device_
     device_registry = MagicMock()
     # After migration, the device row is gone (e.g. migration also dropped it
     # because all config_entries became empty during a partial failure)
-    device_registry.async_get_device.return_value = None
+    device_registry.async_get_devices.return_value = []
 
     with (
         patch(


### PR DESCRIPTION
## 🐛 What

Replace the deprecated `DeviceRegistry.async_get_device(identifiers=...)` lookup, which now raises `RuntimeError` on recent Home Assistant versions because device identifiers are no longer unique across config entries.

## 🔧 Changes

- 🔀 Migration `v1 → v2` and the cross-domain rename step now use `async_get_device_by_identifier(identifier, config_entry_id)`, passing the owning config entry id.
- ♻️ The post-migration device-customization restore uses `async_get_devices(identifiers=...)` instead, because the device was retargeted to a different config entry during the cross-domain migration, so a fixed entry id would no longer match.
- ✅ Test mocks and assertions updated to the new device registry API (`async_get_device_by_identifier`, and `async_get_devices` returning a list).

## 🧪 Testing

- `pytest` green (331 passed), coverage unchanged.
- `basedpyright` 0 errors, `ruff check` and `ruff format --check` clean.

## 📝 Notes

Independent of the number platform work; fixes a preexisting CI failure surfaced by a newer Home Assistant version.
