### PR TITLE
refactor(config): ♻️ move time auto-sync from a switch to an options toggle

### DIFF
--- a/custom_components/neopool/config_flow.py
+++ b/custom_components/neopool/config_flow.py
@@ -41,6 +41,7 @@ from homeassistant.helpers.selector import SelectSelector, SelectSelectorConfig
 # CUSTOM-ONLY END
 from .const import (
     CONF_ADVANCED,
+    CONF_AUTO_TIME_SYNC,
     CONF_DEV_OVERRIDES,
     CONF_DEV_OVERRIDES_ENABLED,
     CONF_FILTRATION_PUMP_POWER,
@@ -242,6 +243,10 @@ class NeoPoolOptionsFlowHandler(OptionsFlowWithReload):
             vol.Optional(
                 CONF_MEASURE_WHEN_FILTRATION_OFF,
                 default=options.get(CONF_MEASURE_WHEN_FILTRATION_OFF, False),
+            ): bool,
+            vol.Optional(
+                CONF_AUTO_TIME_SYNC,
+                default=options.get(CONF_AUTO_TIME_SYNC, False),
             ): bool,
             vol.Optional(
                 CONF_FILTRATION_PUMP_POWER,

--- a/custom_components/neopool/coordinator.py
+++ b/custom_components/neopool/coordinator.py
@@ -351,13 +351,6 @@ class NeoPoolCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._persist_capability_snapshot(data)
         return data
 
-    async def set_auto_time_sync(self, enabled: bool) -> None:
-        """Persist the auto_time_sync flag and refresh the entry options."""
-        self.auto_time_sync = enabled
-        options = dict(self.config_entry.options)
-        options[CONF_AUTO_TIME_SYNC] = enabled
-        self.hass.config_entries.async_update_entry(self.config_entry, options=options)
-
     async def set_winter_mode(self, enabled: bool) -> None:
         """Toggle winter mode via the native disable-polling flag.
 

--- a/custom_components/neopool/helpers.py
+++ b/custom_components/neopool/helpers.py
@@ -50,9 +50,15 @@ def prepare_device_time(hass: HomeAssistant) -> int:
 
 
 def is_device_time_out_of_sync(
-    data: dict[str, Any], hass: HomeAssistant | None = None, threshold_seconds: int = 60
+    data: dict[str, Any],
+    hass: HomeAssistant | None = None,
+    threshold_seconds: int = 300,
 ) -> bool:
-    """Returns True if device time and HA time differ by more than threshold_seconds."""
+    """Returns True if device time and HA time differ by more than threshold_seconds.
+
+    The default is loose on purpose: correct a clock that drifted far (e.g. after
+    a power loss), not small offsets from bus latency or minute-granular RTC.
+    """
     device_dt = get_device_time(data, hass)
     if device_dt is None:
         return False

--- a/custom_components/neopool/icons.json
+++ b/custom_components/neopool/icons.json
@@ -180,7 +180,6 @@
         "default": "mdi:snowflake-alert",
         "state": { "on": "mdi:snowflake-melt" }
       },
-      "time_auto_sync": { "default": "mdi:home-clock-outline" },
       "uv_mode": {
         "default": "mdi:lightbulb-fluorescent-tube-outline",
         "state": {

--- a/custom_components/neopool/migration.py
+++ b/custom_components/neopool/migration.py
@@ -111,6 +111,8 @@ REMOVED_ENTITY_KEYS: tuple[str, ...] = (
     "select.relay_aux*_stop",
     "select.relay_light_start",
     "select.relay_light_stop",
+    # time auto-sync moved from a switch to an options toggle
+    "switch.time_auto_sync",
 )
 
 

--- a/custom_components/neopool/strings.json
+++ b/custom_components/neopool/strings.json
@@ -325,7 +325,6 @@
         "name": "Enable hydrolysis shutdown on high temperature"
       },
       "smart_anti_freeze": { "name": "Smart antifreeze" },
-      "time_auto_sync": { "name": "Time auto sync" },
       "uv_mode": { "name": "UV mode" },
       "winter_mode": { "name": "Winter mode" }
     },
@@ -412,6 +411,7 @@
     "step": {
       "init": {
         "data": {
+          "auto_time_sync": "Automatically sync device clock",
           "filtration_pump_power": "[%key:component::neopool::config::step::user::data::filtration_pump_power%]",
           "measure_when_filtration_off": "Measure values even when filtration is off",
           "scan_interval": "Data update interval (seconds)",
@@ -426,6 +426,7 @@
           "use_light": "Enable Light Relay"
         },
         "data_description": {
+          "auto_time_sync": "When enabled, the controller clock is corrected on each poll if it drifts from Home Assistant time.",
           "filtration_pump_power": "[%key:component::neopool::config::step::user::data_description::filtration_pump_power%]",
           "measure_when_filtration_off": "When disabled, chemical measurements (pH, ORP, etc.) are only taken while the filtration pump is running.",
           "scan_interval": "Lower values increase responsiveness but generate more Modbus traffic.",

--- a/custom_components/neopool/switch.py
+++ b/custom_components/neopool/switch.py
@@ -45,7 +45,6 @@ from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import (
-    CONF_AUTO_TIME_SYNC,
     CONF_USE_AUX1,
     CONF_USE_AUX2,
     CONF_USE_AUX3,
@@ -63,8 +62,7 @@ PARALLEL_UPDATES = 1
 # client, don't participate in the winter-mode guard, and stay available even
 # while winter mode is active.
 _HA_SETTING_WINTER_MODE = CONF_WINTER_MODE
-_HA_SETTING_AUTO_TIME_SYNC = CONF_AUTO_TIME_SYNC
-_HA_SETTING_TYPES = frozenset({_HA_SETTING_WINTER_MODE, _HA_SETTING_AUTO_TIME_SYNC})
+_HA_SETTING_TYPES = frozenset({_HA_SETTING_WINTER_MODE})
 
 
 type _WriteFn = Callable[["NeoPoolSwitch", Any, bool], Awaitable[dict[str, Any]]]
@@ -199,12 +197,6 @@ SWITCH_DESCRIPTIONS: dict[str, NeoPoolSwitchEntityDescription] = {
         translation_key=CONF_WINTER_MODE,
         entity_category=EntityCategory.CONFIG,
         ha_setting=_HA_SETTING_WINTER_MODE,
-    ),
-    "TIME_AUTO_SYNC": NeoPoolSwitchEntityDescription(
-        key="TIME_AUTO_SYNC",
-        translation_key="time_auto_sync",
-        entity_category=EntityCategory.CONFIG,
-        ha_setting=_HA_SETTING_AUTO_TIME_SYNC,
     ),
     "MBF_PAR_FILT_MANUAL_STATE": NeoPoolSwitchEntityDescription(
         key="MBF_PAR_FILT_MANUAL_STATE",
@@ -388,11 +380,6 @@ class NeoPoolSwitch(NeoPoolEntity, SwitchEntity):
             # so there's nothing more to write here.
             await self.coordinator.set_winter_mode(state)
             return
-        if desc.ha_setting == _HA_SETTING_AUTO_TIME_SYNC:
-            await self.coordinator.set_auto_time_sync(state)
-            await self.coordinator.async_request_refresh()
-            self.async_write_ha_state()
-            return
 
         if (
             desc.write_fn is None
@@ -428,8 +415,6 @@ class NeoPoolSwitch(NeoPoolEntity, SwitchEntity):
         desc = self.entity_description
         if desc.is_on_fn is not None:
             return desc.is_on_fn(self.coordinator.data)
-        if desc.ha_setting == _HA_SETTING_AUTO_TIME_SYNC:
-            return getattr(self.coordinator, CONF_AUTO_TIME_SYNC, False)
         if desc.ha_setting == _HA_SETTING_WINTER_MODE:
             return self.coordinator.config_entry.pref_disable_polling
         return False  # pragma: no cover

--- a/custom_components/neopool/translations/cs.json
+++ b/custom_components/neopool/translations/cs.json
@@ -469,9 +469,6 @@
             "smart_anti_freeze": {
                 "name": "Smart: protimrazová ochrana"
             },
-            "time_auto_sync": {
-                "name": "Autosynchronizace času"
-            },
             "uv_mode": {
                 "name": "UV režim"
             },
@@ -589,6 +586,7 @@
         "step": {
             "init": {
                 "data": {
+                    "auto_time_sync": "Automaticky synchronizovat čas zařízení",
                     "filtration_pump_power": "Příkon filtračního čerpadla (W, 0 = zakázáno)",
                     "measure_when_filtration_off": "Měřit hodnoty i při vypnuté filtraci",
                     "scan_interval": "Interval aktualizace dat (v sekundách)",
@@ -603,6 +601,7 @@
                     "use_light": "Povolit relé Osvětlení"
                 },
                 "data_description": {
+                    "auto_time_sync": "Pokud je zapnuto, hodiny ovladače se při každém dotazu opraví, pokud se odchýlí od času Home Assistant.",
                     "filtration_pump_power": "Zadejte jmenovitý příkon filtračního čerpadla. Při nenulové hodnotě se vytvoří dva senzory: okamžitý příkon (W) a kumulativní spotřeba energie (Wh), oba použitelné v přehledu energie.",
                     "measure_when_filtration_off": "Pokud je vypnuto, chemická měření (pH, ORP atd.) probíhají pouze při běžícím filtračním čerpadle.",
                     "scan_interval": "Nižší hodnoty zvyšují rychlost odezvy, ale generují více Modbus komunikace.",

--- a/custom_components/neopool/translations/de.json
+++ b/custom_components/neopool/translations/de.json
@@ -469,9 +469,6 @@
             "smart_anti_freeze": {
                 "name": "Smart: Frostschutz"
             },
-            "time_auto_sync": {
-                "name": "Zeit automatische Synchronisierung"
-            },
             "uv_mode": {
                 "name": "UV-Modus"
             },
@@ -589,6 +586,7 @@
         "step": {
             "init": {
                 "data": {
+                    "auto_time_sync": "Gerätezeit automatisch synchronisieren",
                     "filtration_pump_power": "Leistung der Filtrationspumpe (W, 0 = deaktiviert)",
                     "measure_when_filtration_off": "Messwerte auch bei ausgeschalteter Filterung erfassen",
                     "scan_interval": "Datenaktualisierungsintervall (Sekunden)",
@@ -603,6 +601,7 @@
                     "use_light": "Licht-Relais aktivieren"
                 },
                 "data_description": {
+                    "auto_time_sync": "Wenn aktiviert, wird die Uhr des Reglers bei jeder Abfrage korrigiert, falls sie von der Home Assistant-Zeit abweicht.",
                     "filtration_pump_power": "Geben Sie die Nennleistung der Filtrationspumpe an. Bei einem Wert ungleich null werden zwei Sensoren erstellt: momentane Leistung (W) und kumulierter Energieverbrauch (Wh), beide nutzbar im Energie-Dashboard.",
                     "measure_when_filtration_off": "Wenn deaktiviert, werden chemische Messungen (pH, ORP usw.) nur bei laufender Filterpumpe durchgeführt.",
                     "scan_interval": "Niedrigere Werte erhöhen die Reaktionsfähigkeit, erzeugen aber mehr Modbus-Verkehr.",

--- a/custom_components/neopool/translations/en.json
+++ b/custom_components/neopool/translations/en.json
@@ -472,9 +472,6 @@
             "smart_anti_freeze": {
                 "name": "Smart antifreeze"
             },
-            "time_auto_sync": {
-                "name": "Time auto sync"
-            },
             "uv_mode": {
                 "name": "UV mode"
             },
@@ -589,6 +586,7 @@
         "step": {
             "init": {
                 "data": {
+                    "auto_time_sync": "Automatically sync device clock",
                     "filtration_pump_power": "Filtration pump power (W, 0 = disabled)",
                     "measure_when_filtration_off": "Measure values even when filtration is off",
                     "scan_interval": "Data update interval (seconds)",
@@ -603,6 +601,7 @@
                     "use_light": "Enable Light Relay"
                 },
                 "data_description": {
+                    "auto_time_sync": "When enabled, the controller clock is corrected on each poll if it drifts from Home Assistant time.",
                     "filtration_pump_power": "Set the rated wattage of the filtration pump. When non-zero, two sensors are created: instantaneous power (W) and cumulative energy (Wh), both usable in the Energy dashboard.",
                     "measure_when_filtration_off": "When disabled, chemical measurements (pH, ORP, etc.) are only taken while the filtration pump is running.",
                     "scan_interval": "Lower values increase responsiveness but generate more Modbus traffic.",

--- a/custom_components/neopool/translations/es.json
+++ b/custom_components/neopool/translations/es.json
@@ -469,9 +469,6 @@
             "smart_anti_freeze": {
                 "name": "Smart: antiheladas"
             },
-            "time_auto_sync": {
-                "name": "Sincronización automática de hora"
-            },
             "uv_mode": {
                 "name": "Modo UV"
             },
@@ -589,6 +586,7 @@
         "step": {
             "init": {
                 "data": {
+                    "auto_time_sync": "Sincronizar automáticamente la hora del dispositivo",
                     "filtration_pump_power": "Potencia de la bomba de filtración (W, 0 = desactivado)",
                     "measure_when_filtration_off": "Medir valores incluso cuando la filtración está apagada",
                     "scan_interval": "Intervalo de actualización de datos (segundos)",
@@ -603,6 +601,7 @@
                     "use_light": "Activar relé de luz"
                 },
                 "data_description": {
+                    "auto_time_sync": "Cuando está activado, el reloj del controlador se corrige en cada sondeo si difiere de la hora de Home Assistant.",
                     "filtration_pump_power": "Indique la potencia nominal de la bomba de filtración. Con un valor distinto de cero se crean dos sensores: potencia instantánea (W) y energía acumulada (Wh), ambos utilizables en el panel de energía.",
                     "measure_when_filtration_off": "Cuando está desactivado, las mediciones químicas (pH, ORP, etc.) solo se realizan mientras la bomba de filtración está en funcionamiento.",
                     "scan_interval": "Valores más bajos aumentan la capacidad de respuesta pero generan más tráfico Modbus.",

--- a/custom_components/neopool/translations/fr.json
+++ b/custom_components/neopool/translations/fr.json
@@ -469,9 +469,6 @@
             "smart_anti_freeze": {
                 "name": "Smart: antigel"
             },
-            "time_auto_sync": {
-                "name": "Synchronisation automatique de l’heure"
-            },
             "uv_mode": {
                 "name": "Mode UV"
             },
@@ -589,6 +586,7 @@
         "step": {
             "init": {
                 "data": {
+                    "auto_time_sync": "Synchroniser automatiquement l'heure de l'appareil",
                     "filtration_pump_power": "Puissance de la pompe de filtration (W, 0 = désactivé)",
                     "measure_when_filtration_off": "Mesurer les valeurs même lorsque la filtration est arrêtée",
                     "scan_interval": "Intervalle de mise à jour des données (secondes)",
@@ -603,6 +601,7 @@
                     "use_light": "Activer le relais Lumière"
                 },
                 "data_description": {
+                    "auto_time_sync": "Lorsque activé, l'horloge du contrôleur est corrigée à chaque interrogation si elle dévie de l'heure de Home Assistant.",
                     "filtration_pump_power": "Indiquez la puissance nominale de la pompe de filtration. Avec une valeur non nulle, deux capteurs sont créés : puissance instantanée (W) et énergie cumulée (Wh), tous deux utilisables dans le tableau de bord énergétique.",
                     "measure_when_filtration_off": "Lorsque désactivé, les mesures chimiques (pH, ORP, etc.) ne sont effectuées que lorsque la pompe de filtration fonctionne.",
                     "scan_interval": "Des valeurs plus basses augmentent la réactivité mais génèrent plus de trafic Modbus.",

--- a/custom_components/neopool/translations/it.json
+++ b/custom_components/neopool/translations/it.json
@@ -469,9 +469,6 @@
             "smart_anti_freeze": {
                 "name": "Smart: antigelo"
             },
-            "time_auto_sync": {
-                "name": "Sincronizzazione orario automatica"
-            },
             "uv_mode": {
                 "name": "Modalità UV"
             },
@@ -589,6 +586,7 @@
         "step": {
             "init": {
                 "data": {
+                    "auto_time_sync": "Sincronizza automaticamente l'orario del dispositivo",
                     "filtration_pump_power": "Potenza della pompa di filtrazione (W, 0 = disabilitato)",
                     "measure_when_filtration_off": "Misura i valori anche quando la filtrazione è spenta",
                     "scan_interval": "Intervallo aggiornamento dati (secondi)",
@@ -603,6 +601,7 @@
                     "use_light": "Abilita relè luce"
                 },
                 "data_description": {
+                    "auto_time_sync": "Quando abilitato, l'orologio del controller viene corretto ad ogni interrogazione se si discosta dall'orario di Home Assistant.",
                     "filtration_pump_power": "Specificare la potenza nominale della pompa di filtrazione. Con un valore diverso da zero vengono creati due sensori: potenza istantanea (W) ed energia cumulata (Wh), entrambi utilizzabili nel pannello energetico.",
                     "measure_when_filtration_off": "Quando disabilitato, le misurazioni chimiche (pH, ORP, ecc.) vengono effettuate solo quando la pompa di filtrazione è in funzione.",
                     "scan_interval": "Valori più bassi aumentano la reattività ma generano più traffico Modbus.",

--- a/custom_components/neopool/translations/pl.json
+++ b/custom_components/neopool/translations/pl.json
@@ -469,9 +469,6 @@
             "smart_anti_freeze": {
                 "name": "Smart: antyzamarzanie"
             },
-            "time_auto_sync": {
-                "name": "Automatyczna synchronizacja czasu"
-            },
             "uv_mode": {
                 "name": "Tryb UV"
             },
@@ -589,6 +586,7 @@
         "step": {
             "init": {
                 "data": {
+                    "auto_time_sync": "Automatycznie synchronizuj czas urządzenia",
                     "filtration_pump_power": "Moc pompy filtracyjnej (W, 0 = wyłączone)",
                     "measure_when_filtration_off": "Mierz wartości nawet gdy filtracja jest wyłączona",
                     "scan_interval": "Interwał aktualizacji danych (sekundy)",
@@ -603,6 +601,7 @@
                     "use_light": "Włącz przekaźnik oświetlenia"
                 },
                 "data_description": {
+                    "auto_time_sync": "Gdy włączone, zegar sterownika jest korygowany przy każdym odpytaniu, jeśli odbiega od czasu Home Assistant.",
                     "filtration_pump_power": "Podaj nominalną moc pompy filtracyjnej. Przy wartości różnej od zera tworzone są dwa czujniki: chwilowa moc (W) i skumulowana energia (Wh), oba możliwe do użycia na panelu energetycznym.",
                     "measure_when_filtration_off": "Gdy wyłączone, pomiary chemiczne (pH, ORP itp.) są wykonywane tylko podczas pracy pompy filtracyjnej.",
                     "scan_interval": "Niższe wartości zwiększają responsywność, ale generują więcej ruchu Modbus.",

--- a/tests/snapshots/test_switch.ambr
+++ b/tests/snapshots/test_switch.ambr
@@ -499,56 +499,6 @@
     'state': 'off',
   })
 # ---
-# name: test_all_entities[switch.neopool_time_auto_sync-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'switch',
-    'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'switch.neopool_time_auto_sync',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Time auto sync',
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Time auto sync',
-    'platform': 'neopool',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'time_auto_sync',
-    'unique_id': '1234567890_time_auto_sync',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_all_entities[switch.neopool_time_auto_sync-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'NeoPool Time auto sync',
-    }),
-    'context': <ANY>,
-    'entity_id': 'switch.neopool_time_auto_sync',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
 # name: test_all_entities[switch.neopool_uv_mode-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -17,6 +17,7 @@ from custom_components.neopool.config_flow import (
 )
 from custom_components.neopool.const import (
     CONF_ADVANCED,
+    CONF_AUTO_TIME_SYNC,
     CONF_DEV_OVERRIDES,
     CONF_DEV_OVERRIDES_ENABLED,
     CONF_MEASURE_WHEN_FILTRATION_OFF,
@@ -296,6 +297,7 @@ async def test_options_flow_save_changes(
             CONF_USE_AUX4: False,
             "filtration_pump_power": 0,
             CONF_MEASURE_WHEN_FILTRATION_OFF: False,
+            CONF_AUTO_TIME_SYNC: True,
             # CUSTOM-ONLY START
             CONF_ADVANCED: {},
             # CUSTOM-ONLY END
@@ -305,6 +307,7 @@ async def test_options_flow_save_changes(
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert mock_config_entry.options[CONF_USE_LIGHT] is True
     assert mock_config_entry.options[CONF_USE_FILTRATION1] is False
+    assert mock_config_entry.options[CONF_AUTO_TIME_SYNC] is True
 
     # CREATE_ENTRY triggers a background reload of the config entry. Wait for
     # it to finish before the test exits so the pytest-hass fixture can unload

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -108,6 +108,20 @@ def test_is_device_time_out_of_sync_no_data() -> None:
     assert is_device_time_out_of_sync({}, None, threshold_seconds=60) is False
 
 
+def test_is_device_time_out_of_sync_default_threshold() -> None:
+    """The default tolerance is loose: a drift under 5 minutes is ignored."""
+    now = int(dt_util.utcnow().timestamp())
+    data = {"MBF_PAR_TIME": now - 120}  # 2 minutes ago
+    with patch(
+        "homeassistant.util.dt.utcnow",
+        return_value=datetime.fromtimestamp(now, tz=UTC),
+    ):
+        # Under the 300 s default it is not out of sync ...
+        assert is_device_time_out_of_sync(data, None) is False
+        # ... but a tighter explicit threshold still flags it.
+        assert is_device_time_out_of_sync(data, None, threshold_seconds=60) is True
+
+
 # ---------------------------------------------------------------------------
 # has_filtvalve
 # ---------------------------------------------------------------------------

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -704,7 +704,7 @@ async def test_all_entities(
 
 # CUSTOM-ONLY START
 # ---------------------------------------------------------------------------
-# winter_mode / auto_time_sync (HA-side settings, HACS-only switches)
+# winter_mode (HA-side setting, HACS-only switch)
 # ---------------------------------------------------------------------------
 
 
@@ -727,23 +727,6 @@ async def test_winter_mode_turn_on_off(
     await _turn_off(hass, entity_id)
     await hass.async_block_till_done()
     assert mock_config_entry.pref_disable_polling is False
-    assert hass.states.get(entity_id).state == STATE_OFF
-
-
-@pytest.mark.usefixtures("mock_neopool_client")
-async def test_auto_time_sync_turn_on_off(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-) -> None:
-    """Toggling the auto_time_sync switch flips its state."""
-    await setup_integration(hass, mock_config_entry)
-    entity_id = "switch.neopool_time_auto_sync"
-    assert hass.states.get(entity_id).state == STATE_OFF
-
-    await _turn_on(hass, entity_id)
-    assert hass.states.get(entity_id).state == STATE_ON
-
-    await _turn_off(hass, entity_id)
     assert hass.states.get(entity_id).state == STATE_OFF
 
 


### PR DESCRIPTION
## 🎯 Summary

Moves the time auto-sync preference from a dedicated `CONFIG` switch entity into the options flow (a boolean checkbox in the integration settings). This is preparation for the upstream core PR, where a set-and-forget preference like "sync the device clock on drift" fits the options flow better than a switch entity that only ever mirrors an option.

`WINTER_MODE` stays a switch (toggled often, backed by the native `pref_disable_polling` flag); only `TIME_AUTO_SYNC` moves.

## 🔧 What changed

- ⚙️ **Options flow**: add an `auto_time_sync` boolean, placed outside the `CUSTOM-ONLY` markers so it also reaches core.
- 🧹 **Switch platform**: drop the `TIME_AUTO_SYNC` entity, the `_HA_SETTING_AUTO_TIME_SYNC` marker, and the auto-sync branches in `is_on` / `_async_set_state`.
- ♻️ **Coordinator**: delete the now-dead `set_auto_time_sync`. The flag is still read from `entry.options` in `__init__`, and the drift-sync logic in `_async_update_data` is unchanged.
- 🗑️ **Migration**: sweep the orphaned switch row via `REMOVED_ENTITY_KEYS` (`switch.time_auto_sync`).
- 🌍 **Strings**: move the label from the switch entity block into the options step across `strings.json` and all bundled locales (en, cs, de, es, fr, it, pl); drop the switch icon.
- ✅ **Tests**: remove the switch toggle test, add an options round-trip assertion, and refresh the switch snapshot.

## ⏲️ Drift threshold

Also loosens the default drift tolerance in `is_device_time_out_of_sync` from 60 s to 300 s. The purpose of auto-sync is correcting a clock that drifted far (e.g. after a device power loss), not chasing small offsets from bus latency or the controller's minute-granular RTC. The threshold stays a fixed value rather than being tied to the poll interval: it reflects the device clock, not how often we poll, and it is shared with the `device_time_out_of_sync` diagnostic sensor.

## 🔁 Backwards compatibility

The stored key is unchanged (`entry.options["auto_time_sync"]`), so setups that had the switch enabled keep the feature enabled: the options checkbox reads the same value and shows up already ticked. The migration only removes the stale switch entity from the registry, it does not touch the stored value.

## ⏱️ How auto-sync works now

1. The user ticks the option, the entry reloads (`OptionsFlowWithReload`).
2. The reload rebuilds the coordinator, which reads `auto_time_sync` from options in `__init__`.
3. On each poll, if the flag is set and the device clock drifts from HA time, the controller clock is corrected.

## ✅ Verification

- `ruff check` and `ruff format --check`: clean
- `basedpyright`: 0 errors
- `pytest --cov`: 330 passed, 100% coverage maintained
