### PR TITLE
fix(config): 🐛 harden winter mode against external flag toggles and options-flow snapshot loss

### DIFF
--- a/custom_components/neopool/binary_sensor.py
+++ b/custom_components/neopool/binary_sensor.py
@@ -396,7 +396,6 @@ async def async_setup_entry(
 class NeoPoolBinarySensor(NeoPoolEntity, BinarySensorEntity):
     """Representation of a NeoPool binary sensor."""
 
-    _winter_mode_active = False
     entity_description: NeoPoolBinarySensorEntityDescription
 
     def __init__(

--- a/custom_components/neopool/config_flow.py
+++ b/custom_components/neopool/config_flow.py
@@ -42,6 +42,7 @@ from homeassistant.helpers.selector import SelectSelector, SelectSelectorConfig
 from .const import (
     CONF_ADVANCED,
     CONF_AUTO_TIME_SYNC,
+    CONF_CAPABILITIES,
     CONF_DEV_OVERRIDES,
     CONF_DEV_OVERRIDES_ENABLED,
     CONF_FILTRATION_PUMP_POWER,
@@ -317,6 +318,11 @@ class NeoPoolOptionsFlowHandler(OptionsFlowWithReload):
             advanced = user_input.pop(CONF_ADVANCED, {})
             user_input.update(advanced)
             # CUSTOM-ONLY END
+            # Preserve the internal capability snapshot the coordinator persists
+            # in options; the form only carries the user-selected toggles, so it
+            # would otherwise drop and break offline setup while winter mode is on.
+            if CONF_CAPABILITIES in options:
+                user_input[CONF_CAPABILITIES] = options[CONF_CAPABILITIES]
             return self.async_create_entry(title="", data=user_input)
 
         return self.async_show_form(

--- a/custom_components/neopool/const.py
+++ b/custom_components/neopool/const.py
@@ -54,9 +54,11 @@ CONF_USE_AUX4 = "use_aux4"
 
 # Internal option keys
 CONF_AUTO_TIME_SYNC = "auto_time_sync"
+# CUSTOM-ONLY START, winter-mode switch is HACS-only.
 # Winter mode is backed by the native config_entry.pref_disable_polling flag;
 # this constant survives only as the winter-mode switch translation_key.
 CONF_WINTER_MODE = "winter_mode"
+# CUSTOM-ONLY END
 CONF_CAPABILITIES = "_capabilities"
 
 # CUSTOM-ONLY START

--- a/custom_components/neopool/coordinator.py
+++ b/custom_components/neopool/coordinator.py
@@ -359,6 +359,7 @@ class NeoPoolCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._persist_capability_snapshot(data)
         return data
 
+    # CUSTOM-ONLY START, winter-mode switch is HACS-only.
     async def set_winter_mode(self, enabled: bool) -> None:
         """Toggle winter mode via the native disable-polling flag.
 
@@ -378,3 +379,5 @@ class NeoPoolCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             updates["options"] = options
         self.hass.config_entries.async_update_entry(self.config_entry, **updates)
         self.hass.config_entries.async_schedule_reload(self.config_entry.entry_id)
+
+    # CUSTOM-ONLY END

--- a/custom_components/neopool/coordinator.py
+++ b/custom_components/neopool/coordinator.py
@@ -88,9 +88,6 @@ class NeoPoolCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         )
         self.client = client
         self.auto_time_sync = entry.options.get(CONF_AUTO_TIME_SYNC, False)
-        # Winter mode maps onto the native per-entry "disable polling" system
-        # option; the base coordinator already skips scheduling when it's set.
-        self.winter_mode = entry.pref_disable_polling
         # Persisted in options for winter mode (no Modbus reads).
         self._capability_snapshot: dict[str, Any] = dict(
             entry.options.get(CONF_CAPABILITIES, {})
@@ -99,6 +96,17 @@ class NeoPoolCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # None (not frozenset()) so the first poll clears any stale issue
         # persisted from a previous session.
         self._corrupted_gpio_state: frozenset[tuple[str, int]] | None = None
+
+    @property
+    def winter_mode(self) -> bool:
+        """Return whether winter mode is active.
+
+        Backed directly by the native per-entry "disable polling" system
+        option, so this stays the single source of truth even when the flag
+        is toggled outside this integration. The base coordinator already
+        skips scheduling refreshes while it is set.
+        """
+        return self.config_entry.pref_disable_polling
 
     def request_refresh_with_followup(
         self, delay: float = FOLLOW_UP_REFRESH_DELAY
@@ -360,7 +368,6 @@ class NeoPoolCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         persisted first so the reload can set entities up offline, then the
         entry is reloaded to rebuild the coordinator with the new flag.
         """
-        self.winter_mode = enabled
         updates: dict[str, Any] = {"pref_disable_polling": enabled}
         if enabled and self.data:
             self._capability_snapshot = {

--- a/custom_components/neopool/entity.py
+++ b/custom_components/neopool/entity.py
@@ -54,8 +54,9 @@ class NeoPoolEntity(CoordinatorEntity[NeoPoolCoordinator]):
     def available(self) -> bool:
         """Return False while winter mode gates this entity.
 
-        Winter mode disables polling, so any entity opting into the gate via
-        _winter_mode_active reports unavailable rather than a stale state.
+        Winter mode disables polling. Entities are gated by default; a
+        subclass can opt out by setting _winter_mode_active to False (the
+        winter mode switch does this so it stays togglable).
         """
         if (
             self._winter_mode_active

--- a/custom_components/neopool/entity.py
+++ b/custom_components/neopool/entity.py
@@ -43,7 +43,7 @@ class NeoPoolEntity(CoordinatorEntity[NeoPoolCoordinator]):
     """Base class for NeoPool entities."""
 
     _attr_has_entity_name = True
-    _winter_mode_active: bool = True
+    _unavailable_in_winter_mode: bool = True
 
     def __init__(self, coordinator: NeoPoolCoordinator) -> None:
         """Initialise the NeoPool base entity."""
@@ -55,11 +55,11 @@ class NeoPoolEntity(CoordinatorEntity[NeoPoolCoordinator]):
         """Return False while winter mode gates this entity.
 
         Winter mode disables polling. Entities are gated by default; a
-        subclass can opt out by setting _winter_mode_active to False (the
-        winter mode switch does this so it stays togglable).
+        subclass can opt out by setting _unavailable_in_winter_mode to False
+        (the winter mode switch does this so it stays togglable).
         """
         if (
-            self._winter_mode_active
+            self._unavailable_in_winter_mode
             and self.coordinator.config_entry.pref_disable_polling
         ):
             return False

--- a/custom_components/neopool/entity.py
+++ b/custom_components/neopool/entity.py
@@ -58,10 +58,7 @@ class NeoPoolEntity(CoordinatorEntity[NeoPoolCoordinator]):
         entities report unavailable. Entities are gated by default; a subclass
         can opt out by setting _unavailable_in_winter_mode to False.
         """
-        if (
-            self._unavailable_in_winter_mode
-            and self.coordinator.config_entry.pref_disable_polling
-        ):
+        if self._unavailable_in_winter_mode and self.coordinator.winter_mode:
             return False
         return super().available
 

--- a/custom_components/neopool/entity.py
+++ b/custom_components/neopool/entity.py
@@ -52,7 +52,11 @@ class NeoPoolEntity(CoordinatorEntity[NeoPoolCoordinator]):
     @property
     @override
     def available(self) -> bool:
-        """Return False for control entities while winter mode is active."""
+        """Return False while winter mode gates this entity.
+
+        Winter mode disables polling, so any entity opting into the gate via
+        _winter_mode_active reports unavailable rather than a stale state.
+        """
         if (
             self._winter_mode_active
             and self.coordinator.config_entry.pref_disable_polling

--- a/custom_components/neopool/entity.py
+++ b/custom_components/neopool/entity.py
@@ -54,9 +54,9 @@ class NeoPoolEntity(CoordinatorEntity[NeoPoolCoordinator]):
     def available(self) -> bool:
         """Return False while winter mode gates this entity.
 
-        Winter mode disables polling. Entities are gated by default; a
-        subclass can opt out by setting _unavailable_in_winter_mode to False
-        (the winter mode switch does this so it stays togglable).
+        Winter mode (the native disable-polling flag) stops updates, so gated
+        entities report unavailable. Entities are gated by default; a subclass
+        can opt out by setting _unavailable_in_winter_mode to False.
         """
         if (
             self._unavailable_in_winter_mode

--- a/custom_components/neopool/sensor.py
+++ b/custom_components/neopool/sensor.py
@@ -363,7 +363,6 @@ _MEASURE_KEYS_REQUIRING_FILTRATION = frozenset(
 class NeoPoolSensor(NeoPoolEntity, SensorEntity):
     """Representation of a NeoPool sensor."""
 
-    _winter_mode_active = False
     entity_description: NeoPoolSensorEntityDescription
 
     def __init__(
@@ -445,7 +444,6 @@ class NeoPoolFiltrationEnergySensor(NeoPoolEntity, RestoreSensor):
     Suitable for the Energy dashboard "Individual devices" energy tracking.
     """
 
-    _winter_mode_active = False
     _attr_device_class = SensorDeviceClass.ENERGY
     _attr_state_class = SensorStateClass.TOTAL_INCREASING
     _attr_native_unit_of_measurement = UnitOfEnergy.WATT_HOUR

--- a/custom_components/neopool/switch.py
+++ b/custom_components/neopool/switch.py
@@ -357,7 +357,7 @@ class NeoPoolSwitch(NeoPoolEntity, SwitchEntity):
 
         # The winter_mode switch itself must remain available while winter mode is on.
         if description.ha_setting == _HA_SETTING_WINTER_MODE:
-            self._winter_mode_active = False
+            self._unavailable_in_winter_mode = False
 
     @override
     async def async_turn_on(self, **kwargs: Any) -> None:
@@ -375,9 +375,6 @@ class NeoPoolSwitch(NeoPoolEntity, SwitchEntity):
 
         # HA-side settings live entirely outside the Modbus client.
         if desc.ha_setting == _HA_SETTING_WINTER_MODE:
-            # set_winter_mode flips pref_disable_polling and schedules an entry
-            # reload, which rebuilds the coordinator and re-renders this entity,
-            # so there's nothing more to write here.
             await self.coordinator.set_winter_mode(state)
             return
 

--- a/custom_components/neopool/switch.py
+++ b/custom_components/neopool/switch.py
@@ -50,7 +50,9 @@ from .const import (
     CONF_USE_AUX3,
     CONF_USE_AUX4,
     CONF_USE_COVER_SENSOR,
+    # CUSTOM-ONLY START, winter-mode switch is HACS-only.
     CONF_WINTER_MODE,
+    # CUSTOM-ONLY END
     DOMAIN,
 )
 from .coordinator import NeoPoolConfigEntry, NeoPoolCoordinator
@@ -58,11 +60,13 @@ from .entity import NeoPoolEntity
 
 PARALLEL_UPDATES = 1
 
+# CUSTOM-ONLY START, winter-mode switch is HACS-only.
 # Switch types that are HA-side settings, not device state: they don't need a
 # client, don't participate in the winter-mode guard, and stay available even
 # while winter mode is active.
 _HA_SETTING_WINTER_MODE = CONF_WINTER_MODE
 _HA_SETTING_TYPES = frozenset({_HA_SETTING_WINTER_MODE})
+# CUSTOM-ONLY END
 
 
 type _WriteFn = Callable[["NeoPoolSwitch", Any, bool], Awaitable[dict[str, Any]]]
@@ -73,7 +77,9 @@ type _IsOnFn = Callable[[dict[str, Any]], bool]
 class NeoPoolSwitchEntityDescription(SwitchEntityDescription):
     """Describes a NeoPool switch entity."""
 
+    # CUSTOM-ONLY START, ha_setting backs the HACS-only winter-mode switch.
     ha_setting: str | None = None
+    # CUSTOM-ONLY END
     supported_fn: Callable[[dict[str, Any]], bool] | None = None
     write_fn: _WriteFn | None = None
     is_on_fn: _IsOnFn | None = None
@@ -192,12 +198,14 @@ def _make_is_on_bitmask(data_key: str, mask: int) -> _IsOnFn:
 
 
 SWITCH_DESCRIPTIONS: dict[str, NeoPoolSwitchEntityDescription] = {
+    # CUSTOM-ONLY START, winter-mode switch is HACS-only.
     "WINTER_MODE": NeoPoolSwitchEntityDescription(
         key="WINTER_MODE",
         translation_key=CONF_WINTER_MODE,
         entity_category=EntityCategory.CONFIG,
         ha_setting=_HA_SETTING_WINTER_MODE,
     ),
+    # CUSTOM-ONLY END
     "MBF_PAR_FILT_MANUAL_STATE": NeoPoolSwitchEntityDescription(
         key="MBF_PAR_FILT_MANUAL_STATE",
         translation_key="filt_manual_state",
@@ -355,9 +363,11 @@ class NeoPoolSwitch(NeoPoolEntity, SwitchEntity):
             f"{self.coordinator.config_entry.unique_id}_{description.key.lower()}"
         )
 
+        # CUSTOM-ONLY START, winter-mode switch is HACS-only.
         # The winter_mode switch itself must remain available while winter mode is on.
         if description.ha_setting == _HA_SETTING_WINTER_MODE:
             self._unavailable_in_winter_mode = False
+        # CUSTOM-ONLY END
 
     @override
     async def async_turn_on(self, **kwargs: Any) -> None:
@@ -373,10 +383,12 @@ class NeoPoolSwitch(NeoPoolEntity, SwitchEntity):
         """Dispatch turn_on / turn_off via the description callables."""
         desc = self.entity_description
 
+        # CUSTOM-ONLY START, winter-mode switch is HACS-only.
         # HA-side settings live entirely outside the Modbus client.
         if desc.ha_setting == _HA_SETTING_WINTER_MODE:
             await self.coordinator.set_winter_mode(state)
             return
+        # CUSTOM-ONLY END
 
         if (
             desc.write_fn is None
@@ -412,10 +424,13 @@ class NeoPoolSwitch(NeoPoolEntity, SwitchEntity):
         desc = self.entity_description
         if desc.is_on_fn is not None:
             return desc.is_on_fn(self.coordinator.data)
+        # CUSTOM-ONLY START, winter-mode switch is HACS-only.
         if desc.ha_setting == _HA_SETTING_WINTER_MODE:
             return self.coordinator.config_entry.pref_disable_polling
-        return False  # pragma: no cover
+        # CUSTOM-ONLY END
+        return False  # pragma: no cover - all device switches wire is_on_fn
 
+    # CUSTOM-ONLY START, winter-mode switch is HACS-only.
     @property
     @override
     def available(self) -> bool:
@@ -424,3 +439,5 @@ class NeoPoolSwitch(NeoPoolEntity, SwitchEntity):
         if self.entity_description.ha_setting in _HA_SETTING_TYPES:
             return True
         return super().available
+
+    # CUSTOM-ONLY END

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -14,8 +14,21 @@ from pytest_homeassistant_custom_component.common import (
 )
 from syrupy.assertion import SnapshotAssertion
 
+from custom_components.neopool.const import (
+    CONF_CAPABILITIES,
+    CONF_MODBUS_FRAMER,
+    CONF_UNIT_ID,
+    CURRENT_VERSION,
+    DOMAIN,
+)
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
-from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNKNOWN, Platform
+from homeassistant.const import (
+    STATE_OFF,
+    STATE_ON,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+    Platform,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 import homeassistant.util.dt as dt_util
@@ -304,3 +317,36 @@ async def test_device_time_drift(
     )
     assert state is not None
     assert state.state == STATE_ON
+
+
+async def test_binary_sensor_unavailable_in_winter_mode(
+    hass: HomeAssistant,
+    mock_neopool_client: MagicMock,
+) -> None:
+    """Binary sensors are unavailable while winter mode is active.
+
+    The device is offline, so read-only entities report unavailable rather
+    than unknown, matching the control entities.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Winter Pool",
+        unique_id="neopool_winter_binary",
+        version=CURRENT_VERSION,
+        pref_disable_polling=True,
+        data={
+            "host": "192.0.2.8",
+            "port": 502,
+            "name": "Winter Pool",
+            CONF_UNIT_ID: 1,
+            CONF_MODBUS_FRAMER: "tcp",
+        },
+        options={
+            CONF_MODBUS_FRAMER: "tcp",
+            CONF_CAPABILITIES: {"MBF_PAR_FILT_GPIO": 1},
+        },
+    )
+    await setup_integration(hass, entry)
+    state = _binary_state(hass, entry, "Filtration Pump")
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -319,9 +319,9 @@ async def test_device_time_drift(
     assert state.state == STATE_ON
 
 
+@pytest.mark.usefixtures("mock_neopool_client")
 async def test_binary_sensor_unavailable_in_winter_mode(
     hass: HomeAssistant,
-    mock_neopool_client: MagicMock,
 ) -> None:
     """Binary sensors are unavailable while winter mode is active.
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -18,6 +18,7 @@ from custom_components.neopool.config_flow import (
 from custom_components.neopool.const import (
     CONF_ADVANCED,
     CONF_AUTO_TIME_SYNC,
+    CONF_CAPABILITIES,
     CONF_DEV_OVERRIDES,
     CONF_DEV_OVERRIDES_ENABLED,
     CONF_MEASURE_WHEN_FILTRATION_OFF,
@@ -32,6 +33,8 @@ from custom_components.neopool.const import (
     CONF_USE_FILTRATION2,
     CONF_USE_FILTRATION3,
     CONF_USE_LIGHT,
+    CURRENT_VERSION,
+    DEFAULT_UNIT_ID,
     DOMAIN,
 )
 from homeassistant.config_entries import SOURCE_USER, ConfigEntryState
@@ -312,6 +315,58 @@ async def test_options_flow_save_changes(
     # CREATE_ENTRY triggers a background reload of the config entry. Wait for
     # it to finish before the test exits so the pytest-hass fixture can unload
     # cleanly and no coordinator refresh timer lingers.
+    await hass.async_block_till_done()
+
+
+@pytest.mark.usefixtures("mock_neopool_client")
+async def test_options_flow_preserves_capability_snapshot(
+    hass: HomeAssistant,
+) -> None:
+    """The options flow keeps the capability snapshot while winter mode is on.
+
+    In winter mode the coordinator skips the poll, so the snapshot persisted in
+    options is the only source for offline setup; the flow must not drop it.
+    """
+    snapshot = {"MBF_PAR_FILT_GPIO": 1, "MBF_PAR_LIGHTING_GPIO": 2}
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=MOCK_SERIAL,
+        version=CURRENT_VERSION,
+        pref_disable_polling=True,
+        data={
+            CONF_HOST: MOCK_HOST,
+            CONF_PORT: MOCK_PORT,
+            CONF_UNIT_ID: DEFAULT_UNIT_ID,
+            CONF_MODBUS_FRAMER: "tcp",
+        },
+        options={CONF_CAPABILITIES: snapshot},
+    )
+    await setup_integration(hass, entry)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {
+            CONF_USE_FILTRATION1: False,
+            CONF_USE_FILTRATION2: False,
+            CONF_USE_FILTRATION3: False,
+            CONF_USE_LIGHT: True,
+            CONF_USE_COVER_SENSOR: False,
+            CONF_USE_AUX1: False,
+            CONF_USE_AUX2: False,
+            CONF_USE_AUX3: False,
+            CONF_USE_AUX4: False,
+            "filtration_pump_power": 0,
+            CONF_MEASURE_WHEN_FILTRATION_OFF: False,
+            CONF_AUTO_TIME_SYNC: False,
+            CONF_ADVANCED: {},
+        },
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert entry.options[CONF_USE_LIGHT] is True
+    assert entry.options[CONF_CAPABILITIES] == snapshot
+
     await hass.async_block_till_done()
 
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -15,6 +15,7 @@ from pytest_homeassistant_custom_component.common import (
 from syrupy.assertion import SnapshotAssertion
 
 from custom_components.neopool.const import (
+    CONF_CAPABILITIES,
     CONF_MEASURE_WHEN_FILTRATION_OFF,
     CONF_MODBUS_FRAMER,
     CONF_UNIT_ID,
@@ -22,7 +23,12 @@ from custom_components.neopool.const import (
     DOMAIN,
 )
 from homeassistant.components.sensor import ATTR_OPTIONS, DOMAIN as SENSOR_DOMAIN
-from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT, STATE_UNKNOWN, Platform
+from homeassistant.const import (
+    ATTR_UNIT_OF_MEASUREMENT,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+    Platform,
+)
 from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers import entity_registry as er
 
@@ -544,3 +550,41 @@ async def test_cell_runtime_sensor_returns_none_when_key_missing(
 
 
 # CUSTOM-ONLY END
+
+
+async def test_sensor_unavailable_in_winter_mode(
+    hass: HomeAssistant,
+) -> None:
+    """Sensors are unavailable while winter mode is active.
+
+    The device is offline, so read-only entities report unavailable rather
+    than unknown, matching the control entities.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Winter Pool",
+        unique_id="neopool_winter_sensor",
+        version=CURRENT_VERSION,
+        pref_disable_polling=True,
+        data={
+            "host": "192.0.2.9",
+            "port": 502,
+            "name": "Winter Pool",
+            CONF_UNIT_ID: 1,
+            CONF_MODBUS_FRAMER: "tcp",
+        },
+        options={
+            CONF_MODBUS_FRAMER: "tcp",
+            CONF_CAPABILITIES: {"MBF_PAR_FILT_GPIO": 1},
+        },
+    )
+    await setup_integration(hass, entry)
+    registry = er.async_get(hass)
+    states = [
+        hass.states.get(e.entity_id)
+        for e in er.async_entries_for_config_entry(registry, entry.entry_id)
+        if e.domain == SENSOR_DOMAIN
+    ]
+    states = [s for s in states if s is not None]
+    assert states, "no sensor entities registered in winter mode"
+    assert all(s.state == STATE_UNAVAILABLE for s in states)

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -554,6 +554,7 @@ async def test_cell_runtime_sensor_returns_none_when_key_missing(
 
 async def test_sensor_unavailable_in_winter_mode(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
 ) -> None:
     """Sensors are unavailable while winter mode is active.
 
@@ -579,12 +580,13 @@ async def test_sensor_unavailable_in_winter_mode(
         },
     )
     await setup_integration(hass, entry)
-    registry = er.async_get(hass)
-    states = [
-        hass.states.get(e.entity_id)
-        for e in er.async_entries_for_config_entry(registry, entry.entry_id)
-        if e.domain == SENSOR_DOMAIN
+
+    entries = er.async_entries_for_config_entry(entity_registry, entry.entry_id)
+    sensors = [
+        e for e in entries if e.domain == SENSOR_DOMAIN and e.disabled_by is None
     ]
-    states = [s for s in states if s is not None]
-    assert states, "no sensor entities registered in winter mode"
-    assert all(s.state == STATE_UNAVAILABLE for s in states)
+    assert sensors
+    for sensor in sensors:
+        state = hass.states.get(sensor.entity_id)
+        assert state is not None
+        assert state.state == STATE_UNAVAILABLE

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -730,9 +730,9 @@ async def test_winter_mode_turn_on_off(
     assert hass.states.get(entity_id).state == STATE_OFF
 
 
+@pytest.mark.usefixtures("mock_neopool_client")
 async def test_io_switch_unavailable_in_winter_mode(
     hass: HomeAssistant,
-    mock_neopool_client: MagicMock,
 ) -> None:
     """IO switches become unavailable while winter mode is active.
 

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -37,11 +37,12 @@ from homeassistant.const import (
     SERVICE_TURN_ON,
     STATE_OFF,
     STATE_ON,
+    STATE_UNAVAILABLE,
     Platform,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
-from homeassistant.helpers import entity_platform as ep, entity_registry as er
+from homeassistant.helpers import entity_registry as er
 
 from . import setup_integration
 from .conftest import MOCK_POOL_DATA
@@ -736,9 +737,8 @@ async def test_io_switch_unavailable_in_winter_mode(
 ) -> None:
     """IO switches become unavailable while winter mode is active.
 
-    HA's service layer refuses to dispatch to unavailable entities, so the
-    availability gate on NeoPoolEntity is what actually blocks IO writes.
-    Assert that gate directly on the entity instance.
+    The device is offline, so IO switches report unavailable, while the
+    winter_mode switch itself stays available so users can toggle it.
     """
     entry = MockConfigEntry(
         domain="neopool",
@@ -760,23 +760,16 @@ async def test_io_switch_unavailable_in_winter_mode(
         },
     )
     await setup_integration(hass, entry)
-    platform = next(
-        p for p in ep.async_get_platforms(hass, "neopool") if p.domain == "switch"
-    )
-    io_entity = next(
-        e
-        for e in platform.entities.values()
-        if getattr(e.entity_description, "key", None) == "MBF_PAR_FILT_MANUAL_STATE"
-    )
-    winter_entity = next(
-        e
-        for e in platform.entities.values()
-        if getattr(e.entity_description, "key", None) == "WINTER_MODE"
-    )
-    # IO switch inherits the winter-mode availability gate.
-    assert io_entity.available is False
-    # The winter_mode switch itself must stay available so users can toggle it.
-    assert winter_entity.available is True
+
+    io_id = _entity_id_by_suffix(hass, entry, "_mbf_par_filt_manual_state")
+    io_state = hass.states.get(io_id)
+    assert io_state is not None
+    assert io_state.state == STATE_UNAVAILABLE
+
+    winter_id = _entity_id_by_suffix(hass, entry, "_winter_mode")
+    winter_state = hass.states.get(winter_id)
+    assert winter_state is not None
+    assert winter_state.state != STATE_UNAVAILABLE
 
 
 # CUSTOM-ONLY END

--- a/tools/sync_to_core/__main__.py
+++ b/tools/sync_to_core/__main__.py
@@ -29,6 +29,7 @@ from .config import (
     EXCLUDE_INTEGRATION_FILES,
     EXCLUDE_TEST_DIRS,
     EXCLUDE_TEST_FILES,
+    ICONS_DROP_KEYS,
     INCLUDE_TRANSLATION_FILES,
     RUFF_DIST_CONFIG,
     SOURCE_INTEGRATION,
@@ -127,6 +128,16 @@ def _process_integration_file(
             strip_translations_en_json(
                 src.read_text(encoding="utf-8"),
                 escape_non_ascii=escape_translations,
+            ),
+        )
+        return
+    # icons.json — drop HACS-only entity-icon subtrees, then reformat to
+    # core style. Kept ahead of the generic `.json` branch below.
+    if src.name == "icons.json":
+        _write(
+            dest,
+            format_strings_style(
+                src.read_text(encoding="utf-8"), paths=ICONS_DROP_KEYS
             ),
         )
         return

--- a/tools/sync_to_core/config.py
+++ b/tools/sync_to_core/config.py
@@ -155,6 +155,17 @@ JSON_DROP_KEYS: tuple[str, ...] = (
     "options.step.init.data.enable_backwash_option",
     "options.step.init.data_description.enable_backwash_option",
     "options.error",
+    # Winter-mode switch is HACS-only (core drives winter mode via the
+    # native pref_disable_polling flag, with no switch entity).
+    "entity.switch.winter_mode",
+)
+
+# JSON key paths to delete from `icons.json`. Kept separate from
+# JSON_DROP_KEYS because icons.json only carries entity-icon subtrees, not
+# the config/options/issues strings that JSON_DROP_KEYS targets.
+ICONS_DROP_KEYS: tuple[str, ...] = (
+    # Winter-mode switch is HACS-only (see JSON_DROP_KEYS above).
+    "entity.switch.winter_mode",
 )
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## ♻️ What changed

**1. Winter mode single source of truth**
Winter mode was tracked twice: a cached `self.winter_mode` attribute on the coordinator, and the native `config_entry.pref_disable_polling` flag it mirrors. This drops the attribute and exposes `winter_mode` as a read-only property backed directly by `pref_disable_polling`.

**2. Preserve capability snapshot across the options flow**
The options flow replaced the full options dict with only the user-selected toggles, dropping the internal `_capabilities` snapshot the coordinator persists. That broke offline platform setup after a restart while winter mode was on. The existing snapshot is now carried over when saving the form.

**3. Scope the winter-mode switch to HACS-only**
Core drives winter mode purely from the native `pref_disable_polling` flag, with no switch entity (an entity mutating an admin-gated system preference has no core precedent). The HACS build keeps the discoverable, automatable `switch.neopool_winter_mode` as a thin surface over that same flag. The switch, its description, the `ha_setting` mechanism, and the winter-mode translations/icons are now wrapped in `# CUSTOM-ONLY` markers and dropped from the sync-to-core output, so both builds share one passive winter-mode core.

## 🎯 Why

- 🧭 The `pref_disable_polling` flag is the **single source of truth**, even when toggled outside the integration (System Options in the UI).
- 🛡️ Prevents a manual refresh from talking Modbus after the flag is flipped elsewhere but before the entry reload rebuilds the coordinator.
- 🧊 Keeps entities visible after a restart while winter mode is on: with polling disabled the persisted snapshot is the only setup source, so the options flow must not drop it.
- 🧩 Keeps the HACS switch (handy for a seasonal schedule or temperature trigger) while the core mirror stays switch-free and passive.

## ✅ Testing

- `pytest` all pass, coverage 100%
- `basedpyright` 0 errors
- `ruff check` / `ruff format --check` clean
- sync-to-core dist tree parses and matches the passive core shape (no switch, no `ha_setting`, winter translations/icons stripped)
