### PR TITLE
fix(number): 🐛 correct packed heating/intelligent temperature setpoint

### DIFF
--- a/.github/workflows/typecheck.yaml
+++ b/.github/workflows/typecheck.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade pip
-          pip install basedpyright homeassistant-stubs 'neopool-modbus>=4.5.3'
+          pip install basedpyright homeassistant-stubs 'neopool-modbus>=4.7.0'
 
       - name: Run BasedPyright
         run: basedpyright custom_components/neopool

--- a/custom_components/neopool/manifest.json
+++ b/custom_components/neopool/manifest.json
@@ -8,6 +8,6 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/svasek/homeassistant-neopool-modbus/issues",
   "loggers": ["neopool_modbus"],
-  "requirements": ["neopool-modbus>=4.5.3"],
+  "requirements": ["neopool-modbus>=4.7.0"],
   "version": "6.7.2"
 }

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 # Runtime dependency (Modbus communication via NeoPool library)
-neopool-modbus>=4.5.3
+neopool-modbus>=4.7.0
 
 # Type stubs for Home Assistant Core
 homeassistant-stubs


### PR DESCRIPTION
## ⬆️ Dependency bump

Bumps `neopool-modbus` from `>=4.5.3` to `>=4.7.0`.

## 🐛 What it fixes

Library 4.7.0 fixes the packed heating/intelligent temperature setpoint on affected firmware (reported on Hayward AquaRite+):

- 🔍 The heating setpoint (`MBF_PAR_HEATING_TEMP`, 0x0416) and intelligent setpoint (`MBF_PAR_INTELLIGENT_TEMP`, 0x041C) are byte-packed on this firmware: low byte = setpoint, high byte = independent measured-temperature telemetry. Before, the raw word read back as e.g. `6430` instead of `30`.
- ✍️ Writes now read-modify-write only the low byte, preserving the high-byte telemetry instead of clobbering it.
- 🧹 As a side effect, the coordinator auto-sync no longer fires spurious re-syncs on drifting telemetry, since heating and intelligent now compare equal.

## 📁 Changes

- `custom_components/neopool/manifest.json`: requirement pin
- `requirements-dev.txt`: dev pin
- `.github/workflows/typecheck.yaml`: type-check install pin

No integration code change: the coordinator and number entity already consume decoded values and round-trip correctly.

## ✅ Validation

- 335 tests passed, 100% coverage
- `basedpyright`, `ruff check`, `ruff format --check` clean

Resolves #269
