### PR TITLE
chore(sync): 🔧 fence auto-time-sync, time-drift sensor and pump power as HACS-only

### DIFF
--- a/custom_components/neopool/binary_sensor.py
+++ b/custom_components/neopool/binary_sensor.py
@@ -68,6 +68,7 @@ def _gpio_ok(gpio_key: str) -> _SupportedFn:
     return lambda data: gpio_key not in data or is_valid_relay_gpio(data[gpio_key] or 0)
 
 
+# CUSTOM-ONLY START, device time-drift sensor is HACS-only.
 def _device_time_drift(data: dict[str, Any], hass: HomeAssistant) -> bool | None:
     """Compute whether the device clock is out of sync with HA.
 
@@ -79,6 +80,7 @@ def _device_time_drift(data: dict[str, Any], hass: HomeAssistant) -> bool | None
     return is_device_time_out_of_sync(data, hass)
 
 
+# CUSTOM-ONLY END
 def _pool_cover_open(data: dict[str, Any], hass: HomeAssistant) -> bool | None:
     """Invert the raw cover state for the OPENING device class.
 
@@ -93,6 +95,7 @@ def _pool_cover_open(data: dict[str, Any], hass: HomeAssistant) -> bool | None:
 
 
 BINARY_SENSOR_DESCRIPTIONS: dict[str, NeoPoolBinarySensorEntityDescription] = {
+    # CUSTOM-ONLY START, device time-drift sensor is HACS-only.
     "Device Time Out Of Sync": NeoPoolBinarySensorEntityDescription(
         key="Device Time Out Of Sync",
         translation_key="device_time_out_of_sync",
@@ -100,6 +103,7 @@ BINARY_SENSOR_DESCRIPTIONS: dict[str, NeoPoolBinarySensorEntityDescription] = {
         entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=_device_time_drift,
     ),
+    # CUSTOM-ONLY END
     # Relay states
     "pH Acid Pump": NeoPoolBinarySensorEntityDescription(
         key="pH Acid Pump",

--- a/custom_components/neopool/config_flow.py
+++ b/custom_components/neopool/config_flow.py
@@ -244,6 +244,8 @@ class NeoPoolOptionsFlowHandler(OptionsFlowWithReload):
                 CONF_MEASURE_WHEN_FILTRATION_OFF,
                 default=options.get(CONF_MEASURE_WHEN_FILTRATION_OFF, False),
             ): bool,
+            # CUSTOM-ONLY START, auto device-time sync and filtration
+            # pump-power sensors are HACS-only.
             vol.Optional(
                 CONF_AUTO_TIME_SYNC,
                 default=options.get(CONF_AUTO_TIME_SYNC, False),
@@ -252,6 +254,7 @@ class NeoPoolOptionsFlowHandler(OptionsFlowWithReload):
                 CONF_FILTRATION_PUMP_POWER,
                 default=options.get(CONF_FILTRATION_PUMP_POWER, 0),
             ): vol.All(int, vol.Range(min=0)),
+            # CUSTOM-ONLY END
             vol.Optional(
                 CONF_USE_FILTRATION1,
                 default=options.get(CONF_USE_FILTRATION1, False),

--- a/custom_components/neopool/const.py
+++ b/custom_components/neopool/const.py
@@ -40,7 +40,9 @@ DEFAULT_UNIT_ID = 1
 CONF_UNIT_ID = "unit_id"
 CONF_MODBUS_FRAMER = "modbus_framer"
 
+# CUSTOM-ONLY START, filtration pump-power sensors are HACS-only.
 CONF_FILTRATION_PUMP_POWER = "filtration_pump_power"
+# CUSTOM-ONLY END
 CONF_MEASURE_WHEN_FILTRATION_OFF = "measure_when_filtration_off"
 CONF_USE_FILTRATION1 = "use_filtration1"
 CONF_USE_FILTRATION2 = "use_filtration2"
@@ -53,7 +55,9 @@ CONF_USE_AUX3 = "use_aux3"
 CONF_USE_AUX4 = "use_aux4"
 
 # Internal option keys
+# CUSTOM-ONLY START, automatic device-time sync is HACS-only.
 CONF_AUTO_TIME_SYNC = "auto_time_sync"
+# CUSTOM-ONLY END
 # Winter mode is backed by the native config_entry.pref_disable_polling flag;
 # this constant survives only as the winter-mode switch translation_key.
 CONF_WINTER_MODE = "winter_mode"

--- a/custom_components/neopool/coordinator.py
+++ b/custom_components/neopool/coordinator.py
@@ -87,7 +87,9 @@ class NeoPoolCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             config_entry=entry,
         )
         self.client = client
+        # CUSTOM-ONLY START, automatic device-time sync is HACS-only.
         self.auto_time_sync = entry.options.get(CONF_AUTO_TIME_SYNC, False)
+        # CUSTOM-ONLY END
         # Winter mode maps onto the native per-entry "disable polling" system
         # option; the base coordinator already skips scheduling when it's set.
         self.winter_mode = entry.pref_disable_polling
@@ -320,9 +322,11 @@ class NeoPoolCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             data = await self.client.async_read_all()
             await self._read_timers_into_data(data)
 
+            # CUSTOM-ONLY START, automatic device-time sync is HACS-only.
             if self.auto_time_sync and is_device_time_out_of_sync(data, self.hass):
                 _LOGGER.debug("Device time is out of sync, updating")
                 await self.client.async_sync_device_time(prepare_device_time(self.hass))
+            # CUSTOM-ONLY END
         except (NeoPoolError, OSError, TimeoutError) as err:
             raise UpdateFailed(
                 translation_domain=DOMAIN,
@@ -332,12 +336,14 @@ class NeoPoolCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         self._check_gpio_registers(data)
 
+        # CUSTOM-ONLY START, filtration pump-power sensors are HACS-only.
         pump_power = max(
             0, int(self.config_entry.options.get(CONF_FILTRATION_PUMP_POWER, 0) or 0)
         )
         data[CONF_FILTRATION_PUMP_POWER] = (
             pump_power if data.get("Filtration Pump") else 0
         )
+        # CUSTOM-ONLY END
 
         # CUSTOM-ONLY START
         self._apply_dev_overrides(data)

--- a/custom_components/neopool/helpers.py
+++ b/custom_components/neopool/helpers.py
@@ -30,6 +30,7 @@ import homeassistant.util.dt as dt_util
 from .const import DOMAIN
 
 
+# CUSTOM-ONLY START, device time-drift helpers are HACS-only.
 def get_device_time(
     data: dict[str, Any], hass: HomeAssistant | None = None
 ) -> datetime.datetime | None:
@@ -43,12 +44,14 @@ def get_device_time(
     return decode_device_time(unix_ts, tz)
 
 
+# CUSTOM-ONLY END
 def prepare_device_time(hass: HomeAssistant) -> int:
     """Return the unix timestamp the device should display as local wall-clock."""
     tz = dt_util.get_time_zone(hass.config.time_zone) or datetime.UTC
     return encode_device_time(dt_util.now(tz))
 
 
+# CUSTOM-ONLY START, device time-drift helpers are HACS-only.
 def is_device_time_out_of_sync(
     data: dict[str, Any],
     hass: HomeAssistant | None = None,
@@ -67,6 +70,7 @@ def is_device_time_out_of_sync(
     return diff > threshold_seconds
 
 
+# CUSTOM-ONLY END
 def parse_register_int(raw: int | str, name: str) -> int:
     """Parse a Modbus register value, raising a translated ServiceValidationError."""
     try:

--- a/custom_components/neopool/sensor.py
+++ b/custom_components/neopool/sensor.py
@@ -301,6 +301,7 @@ SENSOR_DESCRIPTIONS: dict[str, NeoPoolSensorEntityDescription] = {
         entity_registry_enabled_default=False,
         supported_fn=is_hydrolysis_present,
     ),
+    # CUSTOM-ONLY START, filtration pump-power sensor is HACS-only.
     CONF_FILTRATION_PUMP_POWER: NeoPoolSensorEntityDescription(
         key=CONF_FILTRATION_PUMP_POWER,
         translation_key=CONF_FILTRATION_PUMP_POWER,
@@ -309,6 +310,7 @@ SENSOR_DESCRIPTIONS: dict[str, NeoPoolSensorEntityDescription] = {
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=0,
     ),
+    # CUSTOM-ONLY END
 }
 
 
@@ -323,10 +325,13 @@ async def async_setup_entry(
     entities: list[SensorEntity] = [
         NeoPoolSensor(coordinator, key, desc)
         for key, desc in SENSOR_DESCRIPTIONS.items()
-        if key != CONF_FILTRATION_PUMP_POWER
-        and (desc.supported_fn is None or desc.supported_fn(coordinator.data))
+        if (desc.supported_fn is None or desc.supported_fn(coordinator.data))
     ]
 
+    # CUSTOM-ONLY START, filtration pump-power sensors are HACS-only.
+    entities = [
+        e for e in entities if e.entity_description.key != CONF_FILTRATION_PUMP_POWER
+    ]
     pump_power = int(entry.options.get(CONF_FILTRATION_PUMP_POWER, 0) or 0)
     if pump_power > 0:
         entities.append(
@@ -337,6 +342,7 @@ async def async_setup_entry(
             )
         )
         entities.append(NeoPoolFiltrationEnergySensor(coordinator, pump_power))
+    # CUSTOM-ONLY END
 
     async_add_entities(entities)
 
@@ -438,6 +444,7 @@ class NeoPoolSensor(NeoPoolEntity, SensorEntity):
         return super().options
 
 
+# CUSTOM-ONLY START, filtration pump-power sensors are HACS-only.
 class NeoPoolFiltrationEnergySensor(NeoPoolEntity, RestoreSensor):
     """Cumulative energy consumed by the filtration pump (Wh).
 
@@ -501,3 +508,5 @@ class NeoPoolFiltrationEnergySensor(NeoPoolEntity, RestoreSensor):
     def native_value(self) -> float:
         """Return accumulated energy in Wh."""
         return round(self._total_wh, 3)
+
+    # CUSTOM-ONLY END

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -57,6 +57,7 @@ async def test_direct_key_reflects_coordinator_value(
     state = _binary_state(hass, mock_config_entry_binary_sensor, "Filtration Pump")
     assert state is not None
     assert state.state == STATE_ON
+    # CUSTOM-ONLY END
 
     mock_neopool_client.async_read_all.return_value = {
         **MOCK_POOL_DATA,
@@ -106,6 +107,7 @@ async def test_pool_cover_inverts_hardware_value(
     state = _binary_state(hass, mock_config_entry_binary_sensor, "Pool Cover")
     assert state is not None
     assert state.state == STATE_ON
+    # CUSTOM-ONLY END
 
 
 async def test_pool_cover_none_yields_unknown(
@@ -185,6 +187,7 @@ async def test_measurement_module_reads_raw_bit(
     )
     assert state is not None
     assert state.state == STATE_ON
+    # CUSTOM-ONLY END
 
     mock_neopool_client.async_read_all.return_value = {
         **MOCK_POOL_DATA,
@@ -253,6 +256,7 @@ async def test_opt_in_entities_absent_without_options(
     assert _binary_state(hass, mock_config_entry, "Filtration Pump") is not None
 
 
+# CUSTOM-ONLY START, device time-drift sensor is HACS-only.
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 @pytest.mark.parametrize("time_zone", ["UTC", "America/New_York"])
 async def test_device_time_drift(
@@ -304,3 +308,4 @@ async def test_device_time_drift(
     )
     assert state is not None
     assert state.state == STATE_ON
+    # CUSTOM-ONLY END

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -295,9 +295,13 @@ async def test_options_flow_save_changes(
             CONF_USE_AUX2: False,
             CONF_USE_AUX3: False,
             CONF_USE_AUX4: False,
+            # CUSTOM-ONLY START, filtration pump-power is HACS-only.
             "filtration_pump_power": 0,
+            # CUSTOM-ONLY END
             CONF_MEASURE_WHEN_FILTRATION_OFF: False,
+            # CUSTOM-ONLY START, automatic device-time sync is HACS-only.
             CONF_AUTO_TIME_SYNC: True,
+            # CUSTOM-ONLY END
             # CUSTOM-ONLY START
             CONF_ADVANCED: {},
             # CUSTOM-ONLY END
@@ -307,7 +311,9 @@ async def test_options_flow_save_changes(
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert mock_config_entry.options[CONF_USE_LIGHT] is True
     assert mock_config_entry.options[CONF_USE_FILTRATION1] is False
+    # CUSTOM-ONLY START, automatic device-time sync is HACS-only.
     assert mock_config_entry.options[CONF_AUTO_TIME_SYNC] is True
+    # CUSTOM-ONLY END
 
     # CREATE_ENTRY triggers a background reload of the config entry. Wait for
     # it to finish before the test exits so the pytest-hass fixture can unload

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -279,6 +279,7 @@ async def test_capability_snapshot_persisted_to_options(
 # ---------------------------------------------------------------------------
 
 
+# CUSTOM-ONLY START, automatic device-time sync is HACS-only.
 async def test_auto_time_sync_writes_when_drift_detected(
     hass: HomeAssistant,
     mock_neopool_client: MagicMock,
@@ -311,6 +312,7 @@ async def test_auto_time_sync_writes_when_drift_detected(
     assert mock_neopool_client.async_sync_device_time.await_count == 1
 
 
+# CUSTOM-ONLY END
 # ---------------------------------------------------------------------------
 # Developer override JSON
 # ---------------------------------------------------------------------------

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -21,6 +21,7 @@ from homeassistant.util import dt as dt_util
 # ---------------------------------------------------------------------------
 
 
+# CUSTOM-ONLY START, device time-drift helpers are HACS-only.
 def test_get_device_time_utc() -> None:
     """Decoded device time matches MBF_PAR_TIME interpreted as a unix timestamp."""
     ts = (0x1234 << 16) | 0x5678
@@ -63,6 +64,7 @@ def test_get_device_time_with_hass(hass: HomeAssistant) -> None:
     assert result == datetime.fromtimestamp(ts, tz=UTC)
 
 
+# CUSTOM-ONLY END
 # ---------------------------------------------------------------------------
 # prepare_device_time
 # ---------------------------------------------------------------------------
@@ -80,6 +82,7 @@ def test_prepare_device_time_returns_unix_timestamp(hass: HomeAssistant) -> None
 # ---------------------------------------------------------------------------
 
 
+# CUSTOM-ONLY START, device time-drift helpers are HACS-only.
 def test_is_device_time_out_of_sync_within_threshold() -> None:
     """A small drift between device and HA returns False."""
     now = int(dt_util.utcnow().timestamp())
@@ -122,6 +125,7 @@ def test_is_device_time_out_of_sync_default_threshold() -> None:
         assert is_device_time_out_of_sync(data, None, threshold_seconds=60) is True
 
 
+# CUSTOM-ONLY END
 # ---------------------------------------------------------------------------
 # has_filtvalve
 # ---------------------------------------------------------------------------

--- a/tools/sync_to_core/__main__.py
+++ b/tools/sync_to_core/__main__.py
@@ -29,6 +29,7 @@ from .config import (
     EXCLUDE_INTEGRATION_FILES,
     EXCLUDE_TEST_DIRS,
     EXCLUDE_TEST_FILES,
+    ICONS_DROP_KEYS,
     INCLUDE_TRANSLATION_FILES,
     RUFF_DIST_CONFIG,
     SOURCE_INTEGRATION,
@@ -130,7 +131,17 @@ def _process_integration_file(
             ),
         )
         return
-    # Other JSON files in the integration root (`icons.json`, future
+    # `icons.json` — strip icon entries for HACS-only entities that have
+    # no core counterpart, then reformat to core style.
+    if src.name == "icons.json":
+        _write(
+            dest,
+            format_strings_style(
+                src.read_text(encoding="utf-8"), paths=ICONS_DROP_KEYS
+            ),
+        )
+        return
+    # Other JSON files in the integration root (future
     # `quality_scale.yaml` siblings) — no key stripping needed, but
     # reformat anyway so an ad-hoc edit (mixed indent, IDE-reordered
     # keys) gets normalised to the core convention here. Cheap defence

--- a/tools/sync_to_core/config.py
+++ b/tools/sync_to_core/config.py
@@ -154,8 +154,33 @@ JSON_DROP_KEYS: tuple[str, ...] = (
     "options.step.init.data_description.unlock_advanced",
     "options.step.init.data.enable_backwash_option",
     "options.step.init.data_description.enable_backwash_option",
+    # Automatic device-time sync option — HACS-only.
+    "options.step.init.data.auto_time_sync",
+    "options.step.init.data_description.auto_time_sync",
+    # Filtration pump-power sensors (power + coupled energy) — HACS-only.
+    "config.step.user.data.filtration_pump_power",
+    "config.step.user.data_description.filtration_pump_power",
+    "options.step.init.data.filtration_pump_power",
+    "options.step.init.data_description.filtration_pump_power",
+    "entity.sensor.filtration_pump_power",
+    "entity.sensor.filtration_pump_energy",
+    # Device time-drift binary sensor — HACS-only.
+    "entity.binary_sensor.device_time_out_of_sync",
     "options.error",
 )
+
+# JSON key paths to delete from `icons.json`. Same dot-path semantics as
+# JSON_DROP_KEYS — used to strip icon entries for HACS-only entities that
+# have no counterpart in the core integration.
+ICONS_DROP_KEYS: tuple[str, ...] = ("entity.binary_sensor.device_time_out_of_sync",)
+
+# Entity ids whose syrupy snapshot blocks are HACS-only. The matching
+# entity is stripped from the dist integration (its CUSTOM-ONLY entity
+# description never reaches core), so the snapshot block it produced must
+# go too, or the core snapshot references an entity that never registers.
+# Matched as a substring of a snapshot `# name:` header, so a single id
+# covers every parametrised test and every `-entry`/`-state` variant.
+SNAPSHOT_DROP_ENTITY_IDS: tuple[str, ...] = ("binary_sensor.neopool_device_time_sync",)
 
 # ---------------------------------------------------------------------------
 # Optional strippers (toggled via CLI flags)

--- a/tools/sync_to_core/transformers.py
+++ b/tools/sync_to_core/transformers.py
@@ -15,6 +15,7 @@ from .config import (
     EXCLUDE_INTEGRATION_FILES,
     LICENSE_HEADER_PREFIX,
     PYTHON_REPLACEMENTS,
+    SNAPSHOT_DROP_ENTITY_IDS,
 )
 
 # Match `# CUSTOM-ONLY START` ... `# CUSTOM-ONLY END` (and the trailing
@@ -291,16 +292,54 @@ def transform_yaml(source: str, *, strip_license: bool) -> str:
 # consistent with the stripped dist conftest fixtures.
 _AMBR_HACS_ONLY_OPTIONS = re.compile(
     r"^[ \t]+'(?:scan_interval|unlock_advanced|enable_backwash_option|"
-    r"dev_overrides|dev_overrides_enabled)':[^\n]*\n",
+    r"dev_overrides|dev_overrides_enabled|auto_time_sync|filtration_pump_power)':[^\n]*\n",
     flags=re.MULTILINE,
 )
 
 
 def transform_snapshot(source: str) -> str:
-    """Strip HACS-only entry-options keys from a syrupy .ambr snapshot.
+    """Strip HACS-only entries from a syrupy .ambr snapshot.
 
-    The snapshot is otherwise copied verbatim — only the lines whose key
-    matches a HACS-only options name are removed. Leaves indentation,
-    surrounding context and ordering intact.
+    Two independent strips run:
+
+    * Whole snapshot blocks (``# name: …`` up to the next ``# ---``) whose
+      header references a HACS-only entity id. The entity never registers
+      in the core mirror, so its snapshot block must not either.
+    * HACS-only entry-options key lines, wherever they appear. These live
+      on kept blocks (device/config-entry snapshots), so only the single
+      line is removed, not the surrounding block.
+
+    Everything else is copied verbatim — indentation, ordering, and
+    surrounding context stay intact.
     """
+    source = _strip_snapshot_entity_blocks(source)
     return _AMBR_HACS_ONLY_OPTIONS.sub("", source)
+
+
+def _strip_snapshot_entity_blocks(source: str) -> str:
+    """Drop syrupy blocks whose ``# name:`` header names a HACS-only entity.
+
+    A block spans from a ``# name: …`` line through its terminating
+    ``# ---`` line (inclusive). We walk block-by-block so the match is
+    anchored to the header only — a HACS-only entity id appearing inside
+    an unrelated block's body never triggers a spurious removal.
+    """
+    if not SNAPSHOT_DROP_ENTITY_IDS:
+        return source
+    lines = source.splitlines(keepends=True)
+    out: list[str] = []
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        if line.startswith("# name:") and any(
+            entity_id in line for entity_id in SNAPSHOT_DROP_ENTITY_IDS
+        ):
+            # Skip through the block terminator (`# ---`) inclusive.
+            i += 1
+            while i < len(lines) and not lines[i].startswith("# ---"):
+                i += 1
+            i += 1  # consume the `# ---` line itself
+            continue
+        out.append(line)
+        i += 1
+    return "".join(out)


### PR DESCRIPTION
## 🎯 What

Fence three HACS-only features so the core mirror emitted by `tools/sync_to_core` no longer contains them, while the HACS package keeps them fully functional:

- 🕒 Automatic device-time synchronization (`CONF_AUTO_TIME_SYNC` option + coordinator poll hook)
- 🚨 The `Device Time Out Of Sync` binary sensor (drift diagnostic) and its `get_device_time` / `is_device_time_out_of_sync` helpers
- ⚡ The `filtration_pump_power` option, which drives two sensors: instantaneous power (W) and the coupled cumulative-energy sensor (Wh)

None of these landed in core, so they must stay out of the sync output.

## 🔧 How

- 🧱 Wrap the call sites, the `const.py` definitions, the drift helpers, the binary-sensor entry, and the pump-power/energy sensors in `# CUSTOM-ONLY START/END` blocks. The blocks are comments, so HACS behaviour is unchanged.
- 🗂️ Add `strings.json` / `translations/en.json` drop paths (`JSON_DROP_KEYS`) and `icons.json` drop paths (`ICONS_DROP_KEYS`) for the dropped keys, so no dangling `[%key%]` translation references remain.
- 📸 Extend `_AMBR_HACS_ONLY_OPTIONS` for the two option keys, and add a new `SNAPSHOT_DROP_ENTITY_IDS` + block stripper so the drift-sensor snapshot blocks are removed from the dist mirror. This keeps the dist snapshot consistent with the stripped `binary_sensor` platform.
- ✅ Fence the matching HACS-only test functions and inline flow-dict keys in place.

`prepare_device_time` and the `SYNC_TIME` button stay in core (the button depends on the helper).

## 🧪 Verification

- 🟢 Custom package: 335 tests pass, 100% coverage, `basedpyright` 0 errors, `ruff check` + `ruff format --check` clean.
- 🟢 Dist mirror integration tree: `ruff` clean, zero references to any stripped name; `SYNC_TIME` button + `prepare_device_time` + `sync_time` string/icon preserved.
- 🟢 No dangling `[%key%]` references in dist `strings.json` / `en.json` / `icons.json`; drift-sensor snapshot blocks gone.

## 📝 Notes

- 🔀 Squash-merge: the PR title is the changelog line.
- 🏷️ No manifest version bump (release-please handles versioning).
